### PR TITLE
Ignore billing models in django-author

### DIFF
--- a/coldfront/config/plugins/ifx.py
+++ b/coldfront/config/plugins/ifx.py
@@ -24,3 +24,10 @@ class FACILITY():
 
 class GROUPS():
     ADMIN_GROUP_NAME = 'rc_admin'
+
+# Ignore billing models in the django-author pre-save so that values are set directly
+AUTHOR_IGNORE_MODELS = [
+    'ifxbilling.BillingRecord',
+    'ifxbilling.Transaction',
+]
+


### PR DESCRIPTION
Ignore billing models in django-author so that values can be set directly