### PR TITLE
User product accounts

### DIFF
--- a/coldfront/plugins/ifx/calculator.py
+++ b/coldfront/plugins/ifx/calculator.py
@@ -132,6 +132,7 @@ class ColdfrontBillingCalculator(BasicBillingCalculator):
                 where
                     hau.allocation_id = %s
                     and po.project_id = a.project_id
+                    and ua.is_valid = 1
                     and pu.year = %s
                     and pu.month = %s
                 group by pu.product_user_id
@@ -148,6 +149,7 @@ class ColdfrontBillingCalculator(BasicBillingCalculator):
                 where
                     hau.allocation_id = %s
                     and po.project_id = a.project_id
+                    and ua.is_valid = 1
                     and pu.year = %s
                     and pu.month = %s
                 group by pu.product_user_id


### PR DESCRIPTION
Make sure that allocation percentage query picks up users with user_product_account entries.
Only use valid accounts for allocation percentage query
