### PR TITLE
Fix allocation percent query

### DIFF
--- a/Dockerfile-ifx
+++ b/Dockerfile-ifx
@@ -6,7 +6,6 @@ RUN apt-get update \
     && apt-get install -y libsasl2-dev libldap2-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir ~/.ssh && echo "Host git*\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-RUN echo 'TLS_REQCERT allow' >> /etc/ldap/ldap.conf
 
 WORKDIR /usr/src/app
 COPY requirements.txt ./

--- a/coldfront/plugins/ifx/calculator.py
+++ b/coldfront/plugins/ifx/calculator.py
@@ -126,15 +126,20 @@ class ColdfrontBillingCalculator(BasicBillingCalculator):
                     product_usage pu inner join ifx_allocationuserproductusage aupu on pu.id = aupu.product_usage_id
                     inner join allocation_historicalallocationuser hau on hau.history_id = aupu.allocation_user_id
                     inner join allocation_allocation a on a.id = hau.allocation_id
-                    inner join user_account ua on ua.user_id = pu.product_user_id
-                    inner join account acct on ua.account_id = acct.id
-                    inner join ifx_projectorganization po on acct.organization_id = po.organization_id
                 where
                     hau.allocation_id = %s
-                    and po.project_id = a.project_id
-                    and ua.is_valid = 1
                     and pu.year = %s
                     and pu.month = %s
+                    and exists (
+                        select 1
+                        from
+                            user_account ua inner join account acct on ua.account_id = acct.id
+                            inner join ifx_projectorganization po on acct.organization_id = po.organization_id
+                        where
+                            po.project_id = a.project_id
+                            and ua.user_id = pu.product_user_id
+                            and ua.is_valid = 1
+                    )
                 group by pu.product_user_id
                 union
                 select
@@ -143,15 +148,20 @@ class ColdfrontBillingCalculator(BasicBillingCalculator):
                     product_usage pu inner join ifx_allocationuserproductusage aupu on pu.id = aupu.product_usage_id
                     inner join allocation_historicalallocationuser hau on hau.history_id = aupu.allocation_user_id
                     inner join allocation_allocation a on a.id = hau.allocation_id
-                    inner join user_product_account ua on ua.user_id = pu.product_user_id
-                    inner join account acct on ua.account_id = acct.id
-                    inner join ifx_projectorganization po on acct.organization_id = po.organization_id
                 where
                     hau.allocation_id = %s
-                    and po.project_id = a.project_id
-                    and ua.is_valid = 1
                     and pu.year = %s
                     and pu.month = %s
+                    and exists (
+                        select 1
+                        from
+                            user_product_account ua inner join account acct on ua.account_id = acct.id
+                            inner join ifx_projectorganization po on acct.organization_id = po.organization_id
+                        where
+                            po.project_id = a.project_id
+                            and ua.user_id = pu.product_user_id
+                            and ua.is_valid = 1
+                    )
                 group by pu.product_user_id
             ) t
             group by product_user_id


### PR DESCRIPTION
Allocation user fraction query was multi-counting usage when there were expense code splits.  Now
uses exists instead of joins