### PR TITLE
Offer letter account + organization

### DIFF
--- a/Dockerfile-ifx
+++ b/Dockerfile-ifx
@@ -10,6 +10,10 @@ RUN mkdir ~/.ssh && echo "Host git*\n\tStrictHostKeyChecking no\n" >> ~/.ssh/con
 WORKDIR /usr/src/app
 COPY requirements.txt ./
 
+ARG IPYTHON_STARTUP=/root/.ipython/profile_default/startup
+RUN mkdir -p ${IPYTHON_STARTUP}
+COPY etc/ipython_init.py ${IPYTHON_STARTUP}
+
 ARG IFXURLS_COMMIT=549af42dbe83d07b12dd37055a5ec6368d4b649
 ARG NANITES_CLIENT_COMMIT=1e67ce787e27c9c0e32a4c97a4967c297d30b7cf
 ARG IFXUSER_COMMIT=4fbf3ee574edf1c2599a059cbd7f05d37cd69c3f

--- a/coldfront/plugins/ifx/calculator.py
+++ b/coldfront/plugins/ifx/calculator.py
@@ -116,7 +116,7 @@ class NewColdfrontBillingCalculator(NewBillingCalculator):
         offer_letter_tb = self.get_offer_letter_tb(allocation)
 
         # Account for offer letter code
-        offer_letter_acct = self.get_offer_letter_account(allocation)
+        offer_letter_acct = self.get_offer_letter_account(allocation, organization)
 
         remaining_tb = allocation_tb
 
@@ -248,7 +248,7 @@ class NewColdfrontBillingCalculator(NewBillingCalculator):
             offer_letter_tb = Decimal(offer_letter_tb)
         return offer_letter_tb
 
-    def get_offer_letter_account(self, allocation):
+    def get_offer_letter_account(self, allocation, organization):
         '''
         Returns the relevant offer letter expense code or None if nothing is found
 
@@ -261,7 +261,7 @@ class NewColdfrontBillingCalculator(NewBillingCalculator):
         code = allocation.get_attribute(self.OFFER_LETTER_CODE_ATTRIBUTE)
         if code:
             try:
-                code = Account.objects.get(code=code)
+                code = Account.objects.get(code=code, organization=organization)
             except Account.DoesNotExist:
                 raise Exception(f'Cannot find offer letter code {code}')
         return code

--- a/etc/ipython_init.py
+++ b/etc/ipython_init.py
@@ -1,0 +1,6 @@
+from django.db import connection
+from ifxbilling.models import *
+from ifxuser.models import *
+from coldfront.plugins.ifx.calculator import NewColdfrontBillingCalculator
+from coldfront.plugins.ifx.models import *
+from coldfront.core.allocation.models import *


### PR DESCRIPTION
Pick offer letter account using the organization, since Linz lab uses SEAS code
Include ipython init so the most models are queued up