### PR TITLE
Clear out ProductUsageProcessing when recalculating billing records

### DIFF
--- a/coldfront/plugins/ifx/calculator.py
+++ b/coldfront/plugins/ifx/calculator.py
@@ -111,7 +111,6 @@ class NewColdfrontBillingCalculator(NewBillingCalculator):
         '''
         successes = []
         errors = []
-
         if organization.org_tree == 'Harvard':
             projects = [po.project for po in organization.projectorganization_set.all()]
             if not projects:

--- a/coldfront/plugins/ifx/views.py
+++ b/coldfront/plugins/ifx/views.py
@@ -113,6 +113,7 @@ def calculate_billing_month(request, year, month):
     try:
         if recalculate:
             ifxbilling_models.BillingRecord.objects.filter(year=year, month=month).delete()
+            ifxbilling_models.ProductUsageProcessing.objects.filter(product_usage__year=year, product_usage__month=month).delete()
         calculator = NewColdfrontBillingCalculator()
         calculator.calculate_billing_month(year, month, recalculate=recalculate)
         return Response('OK', status=status.HTTP_200_OK)


### PR DESCRIPTION
Make sure all PUP records are cleared out when recalculating so that old messages don't stick around
Update ifxbilling to use request.data instead of request.body in update user accounts view; JQuery-based ajax seems
to have accessed the body already, so it can't be reaccessed