### PR TITLE
AllocationUser billing error

### DIFF
--- a/coldfront/plugins/ifx/calculator.py
+++ b/coldfront/plugins/ifx/calculator.py
@@ -143,21 +143,24 @@ class NewColdfrontBillingCalculator(NewBillingCalculator):
                                                 user = get_user_model().objects.get(id=user_id)
                                             except get_user_model().DoesNotExist:
                                                 raise Exception(f'Cannot find user with id {user_id}')
-                                            brs = self.generate_billing_records_for_allocation_user(
-                                                year,
-                                                month,
-                                                user,
-                                                organization,
-                                                allocation,
-                                                allocation_percentage_data['fraction'],
-                                                allocation_tb,
-                                                recalculate,
-                                                remaining_tb,
-                                            )
-                                            if brs:
-                                                allocation_brs.extend(brs)
+                                            try:
+                                                brs = self.generate_billing_records_for_allocation_user(
+                                                    year,
+                                                    month,
+                                                    user,
+                                                    organization,
+                                                    allocation,
+                                                    allocation_percentage_data['fraction'],
+                                                    allocation_tb,
+                                                    recalculate,
+                                                    remaining_tb,
+                                                )
+                                                if brs:
+                                                    allocation_brs.extend(brs)
+                                            except Exception as e:
+                                                logger.error(f'Error generating billing records for user {user} of allocation {allocation}: {e}')
                                         if not allocation_brs:
-                                            raise Exception(f'No billing records created for {organization} allocation {allocation}')
+                                            errors.append(f'No billing recordasdfs created for {organization} allocation {allocation}')
                                         successes.extend(allocation_brs)
                                 except Exception as e:
                                     errors.append(str(e))

--- a/coldfront/plugins/ifx/views.py
+++ b/coldfront/plugins/ifx/views.py
@@ -166,7 +166,6 @@ def calculate_billing_month(request, invoice_prefix, year, month):
         errors = [v[0] for v in resultinator.get_other_errors_by_organization().values()]
 
         return Response(data={ 'successes': successes, 'errors': errors }, status=status.HTTP_200_OK)
-        return Response('OK', status=status.HTTP_200_OK)
     # pylint: disable=broad-exception-caught
     except Exception as e:
         logger.exception(e)


### PR DESCRIPTION
If there is an error getting billing records for one allocation user, don't throw an exception for the entire organization.  Should prevent some errant non-billing.
For calculate billing month, return errors and successes, not just "OK".