### PR TITLE
Better handling for zero tb allocations

### DIFF
--- a/coldfront/plugins/ifx/calculator.py
+++ b/coldfront/plugins/ifx/calculator.py
@@ -401,9 +401,9 @@ class NewColdfrontBillingCalculator(NewBillingCalculator):
         :rtype: `~decimal.Decimal`
         '''
         allocation_size_tb = allocation.get_attribute(self.STORAGE_QUOTA_ATTRIBUTE)
-        if not allocation_size_tb:
+        if allocation_size_tb is None:
             allocation_size_tb = allocation.get_attribute(self.OTHER_STORAGE_QUOTA_ATTRIBUTE)
-        if not allocation_size_tb:
+        if allocation_size_tb is None:
             raise Exception(f'Allocation {allocation.id} ({allocation.get_resources_as_string} for {allocation.project.title}) does not have the {self.STORAGE_QUOTA_ATTRIBUTE} attribute or the {self.OTHER_STORAGE_QUOTA_ATTRIBUTE} attribute set.')
         return Decimal(allocation_size_tb)
 

--- a/coldfront/plugins/ifx/models.py
+++ b/coldfront/plugins/ifx/models.py
@@ -141,7 +141,7 @@ def allocation_user_to_allocation_product_usage(allocation_user, product, overwr
     tb_quantity = Decimal(product_usage_data['quantity'] / 1024**4).quantize(Decimal("100.0000"))
     product_usage_data['decimal_quantity'] = tb_quantity
     allocation_size = allocation_user.allocation.get_attribute('Storage Quota (TiB)')
-    if not allocation_size:
+    if allocation_size is None:
         allocation_size = allocation_user.allocation.get_attribute('Storage Quota (TB)')
     product_usage_data['description'] = f"{tb_quantity.quantize(Decimal('0.00'))} TB of {allocation_size} TB allocation of {product_usage_data['product']} for {product_usage_data['product_user']} on {product_usage_data['start_date']}"
     # pylint: disable=unused-variable
@@ -168,11 +168,11 @@ def update_allocation_product(allocation):
             tb_str = None
             attr_val = allocation.get_attribute(name='Storage Quota (TB)')
             is_active = allocation.status.name == 'Active'
-            if attr_val:
+            if attr_val is not None:
                 tb_str = f"{attr_val} TB"
             else:
                 attr_val = allocation.get_attribute(name='Storage Quota (TiB)')
-                if attr_val:
+                if attr_val is not None:
                     tb_str = f"{attr_val} TiB"
             if tb_str:
                 dir_str = allocation.get_attribute(name='Subdirectory')


### PR DESCRIPTION
Looks like some allocations are set to zero but still around.  Need to allow update_allocation_product to make any product updates and let the billing process them into empty billing records.