### PR TITLE
Hotfix: set root_uid to '0' in isilon utils

### DIFF
--- a/coldfront/plugins/isilon/utils.py
+++ b/coldfront/plugins/isilon/utils.py
@@ -285,7 +285,7 @@ def create_isilon_allocation_quota(
     # determine whether rc_labs or rc_fasse_labs path
     subdir = 'rc_labs' # if 'fasse' not in isilon_resource else 'rc_fasse_labs'
     path = f'ifs/{subdir}/{lab_name}'
-    root_uid = isilon_conn.auth_client.list_auth_users(filter='root').users[0].uid.id
+    root_uid = '0'
 
     ### Set ownership and default permissions ###
     isilon_pi = IsilonUser(allocation.project.pi, isilon_conn)


### PR DESCRIPTION
## Summary
- Replaces the Isilon auth API call for resolving root's UID with the hardcoded value `'0'`

## Test plan
- [ ] Verify `create_isilon_allocation_quota` still sets correct directory ownership