### PR TITLE
Grant lab group read/write access on SMB share creation

### DIFF
--- a/coldfront/plugins/isilon/utils.py
+++ b/coldfront/plugins/isilon/utils.py
@@ -388,6 +388,17 @@ def create_isilon_allocation_quota(
             name=lab_name,
             ntfs_acl_support=False,
             path=f'/{path}',
+            permissions=[
+                isilon_api.SmbSharePermission(
+                    permission='change',
+                    permission_type='allow',
+                    trustee=isilon_api.MemberObject(
+                        id=f'GID:{isilon_group.gid}',
+                        name=isilon_group.name,
+                        type='group',
+                    ),
+                ),
+            ],
         )
         try:
             isilon_conn.protocols_client.create_smb_share(smb_share)


### PR DESCRIPTION
## Summary

- Sets an explicit `change` (read/write) permission for the lab group on the SMB share created in `create_isilon_allocation_quota`
- Replaces the default read-only-for-everyone behavior with access scoped to the lab's GID only

## Test plan

- [x] Create an allocation and verify the SMB share is created with `change` permission for the lab group
- [x] Confirm no other principals (e.g. Everyone) are granted access