### PR TITLE
Add department-level monthly storage report email with PDF attachment

### DIFF
--- a/coldfront/core/department/templates/department/department_storagereport.html
+++ b/coldfront/core/department/templates/department/department_storagereport.html
@@ -1,179 +1,105 @@
 {% extends "common/base.html" %}
-{% load crispy_forms_tags %}
-{% load humanize %}
 {% load static %}
 {% load common_tags %}
 
 {% block ifx_head %}
-
 <style type="text/css">
-  /* 1) Force all Bootstrap flex or overflow containers to behave:
-     remove flex so children CAN break across pages, kill overflow-x  */
   .table-responsive,
   .card-body,
   .card {
     display: block !important;
     overflow: visible !important;
   }
-
-  /* 2) Tell WeasyPrint that tables may break inside, and rows should not split in half */
   table {
     page-break-inside: auto;
     break-inside: auto;
   }
   thead {
-    /* repeat on every page */
     display: table-header-group;
   }
-  tfoot {
-    /* repeat on every page if you need footers */
-    display: table-footer-group;
-  }
   tr {
-    /* don’t slice a row in half */
     page-break-inside: avoid;
     break-inside: avoid;
   }
   tbody {
-    /* allow breaking between rows */
     display: table-row-group;
   }
 </style>
 {% endblock %}
 
-
-{% block title %}
-Department Storage Report
-{% endblock %}
-
+{% block title %}Department Storage Report{% endblock %}
 
 {% block content %}
 
-<div id="alert_div">
-</div>
-
 <div class="mb-3">
-  <h2 class="text-justify">{{ department.name }}</h2>
+  <h2>FAS Research Computing Usage Report</h2>
   <hr>
 </div>
 
-<!-- Start Department Summary -->
-<div class="card mb-3">
-  <div class="card-body">
-    <h3 class="card-title">Department Storage Summary</h3>
-    <p class="card-text text-justify"><strong>Labs in Report: </strong>{{ project_reports|length }}</p>
-    <p class="card-text text-justify"><strong>Total Storage Quota: </strong>{{ department_total.size|floatformat:1 }}</p>
-    <p class="card-text text-justify"><strong>Total Storage Used: </strong>{{ department_total.usage|floatformat:1 }}</p>
-    <p class="card-text text-justify"><strong>Total Monthly Cost: </strong>${{ department_total.cost|floatformat:2 }}</p>
-  </div>
-</div>
-<!-- End Department Summary -->
-
-{% for report in project_reports %}
-<div class="html2pdf__page-break"></div>
-
-<!-- Start Project Heading -->
-<div class="card mb-3">
-  <div class="card-body">
-    <h3 class="card-title">{{ report.project.title }}</h3>
-    <h4 class="card-title">
-      Principal Investigator:
-      {{ report.project.pi.first_name }}
-      {{ report.project.pi.last_name }}
-      ({{ report.project.pi.username }})
-    </h4>
-    <p class="card-text text-justify"><strong>Description: </strong>{{ report.project.description }}</p>
-    <p class="card-text text-justify"><strong>Field of Science: </strong>{{ report.project.field_of_science }}</p>
-    <p class="card-text text-justify"><strong>Project Status: </strong>{{ report.project.status }}</p>
-    <p class="card-text text-justify"><strong>Created: </strong>{{ report.project.created|date:"M. d, Y" }}</p>
-  </div>
-</div>
-<!-- End Project Heading -->
-
-<!-- Start Project Invoice/Allocations -->
+<!-- Usage Summary -->
 <div class="card mb-3">
   <div class="card-header">
-    <h4 class="d-inline"><i class="fas fa-list" aria-hidden="true"></i> Storage Allocations</h4>
-    <span class="badge badge-secondary">{{ report.storage_allocations.count }}</span>
+    <h3><i class="fas fa-list" aria-hidden="true"></i> Usage Summary For: {{ department.name }}</h3>
   </div>
   <div class="card-body">
-    <table class="table table-hover">
+    <table class="table table-bordered table-sm">
+      {% for row in detail_table %}
+        <tr>
+          <th scope="row" class="text-nowrap">{{ row.0 }}:</th>
+          <td>{{ row.1 }}</td>
+        </tr>
+      {% endfor %}
+    </table>
+  </div>
+</div>
+
+<!-- Monthly Storage Invoice Details -->
+<div class="card mb-3">
+  <div class="card-header">
+    <h3 class="d-inline"><i class="fas fa-users" aria-hidden="true"></i> Monthly Storage Invoice Details</h3>
+    <span class="badge badge-secondary">{{ storage_pi_dict.keys|length }}</span>
+  </div>
+  <div class="card-body">
+    <table class="table table-striped table-bordered">
       <thead>
         <tr>
-          <th scope="col">Resource Name</th>
-          <th scope="col">Location</th>
+          <th scope="col">PI</th>
+          <th scope="col">Project</th>
+          <th scope="col">Allocation</th>
           <th scope="col">Users</th>
           <th scope="col">Quota</th>
-          <th scope="col">Used</th>
           <th scope="col">Monthly Cost</th>
         </tr>
       </thead>
       <tbody>
-        {% for allocation in report.storage_allocations %}
-          {% if allocation.status.name == 'Active' %}
-            <tr style="background-color:#FFFFFF">
-              <td>{{ allocation.get_parent_resource.name }}</td>
-              <td>{{ allocation.path }}</td>
-              <td>{{ allocation.allocationuser_set.count }}</td>
-              <td>{{ allocation.size|floatformat:1 }} {{ allocation.get_parent_resource.quantity_label }}</td>
-              <td>{{ allocation.usage|floatformat:1 }}</td>
-              <td>
-                {% if allocation.requires_payment %}
-                  ${{ allocation.cost|floatformat:2}}
-                {% endif %}
-              </td>
-            </tr>
-          {% endif %}
-        {% endfor %}
-      </tbody>
-      {% if report.storage_allocations|length > 1 %}
-        <tfoot>
-          <tr style="background-color:#C2C2C2;font-weight:bold">
-              <td>Total Storage</td>
-              <td></td>
-              <td>{{ report.allocation_total.allocation_user_count }}</td>
-              <td>{{ report.allocation_total.size|floatformat:1}}</td>
-              <td>{{ report.allocation_total.usage|floatformat:1}}</td>
-              <td>${{ report.allocation_total.cost|floatformat:2 }}</td>
+        {% for pi, allocs in storage_pi_dict.items %}
+          <tr style="background-color:#C2C2C2">
+            <td>{{ pi.full_name }}</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>${{ pi.storage_total_price|floatformat:2 }}</td>
           </tr>
-        </tfoot>
-      {% endif %}
-    </table>
-  </div>
-</div>
-<!-- End Project Invoice/Allocations -->
-
-<!-- Start Project Users -->
-<div class="card mb-3">
-  <div class="card-header">
-    <h4 class="d-inline"><i class="fas fa-users" aria-hidden="true"></i> Users</h4>
-    <span class="badge badge-secondary">{{ report.project_users.count }}</span>
-  </div>
-  <div class="card-body">
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th scope="col">Username</th>
-          <th scope="col">Name</th>
-          <th scope="col">Email</th>
-          <th scope="col" class="text-nowrap">Role</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for user in report.project_users %}
-          <tr>
-            <td>{{ user.user.username }}</td>
-            <td>{{ user.user.first_name }} {{ user.user.last_name }}</td>
-            <td>{{ user.user.email }}</td>
-            <td>{{ user.role.name }}</td>
-          </tr>
+          {% for allocation in allocs %}
+            {% if allocation.resources.first.resource_type.name == "Storage" %}
+              <tr style="background-color:#FFFFFF">
+                <td></td>
+                <td>{{ allocation.project.title }}</td>
+                <td>
+                  {{ allocation.resources.first.name }}
+                  {% if allocation.path %}({{ allocation.path }}){% endif %}
+                </td>
+                <td>{{ allocation.allocationuser_set.count }}</td>
+                <td>{{ allocation.size|floatformat:1 }} {{ allocation.unit_label }}</td>
+                <td>${{ allocation.cost|floatformat:2 }}</td>
+              </tr>
+            {% endif %}
+          {% endfor %}
         {% endfor %}
       </tbody>
     </table>
   </div>
 </div>
-<!-- End Project Users -->
-
-{% endfor %}
 
 {% endblock %}

--- a/coldfront/core/department/templates/department/department_storagereport.html
+++ b/coldfront/core/department/templates/department/department_storagereport.html
@@ -1,0 +1,179 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load humanize %}
+{% load static %}
+{% load common_tags %}
+
+{% block ifx_head %}
+
+<style type="text/css">
+  /* 1) Force all Bootstrap flex or overflow containers to behave:
+     remove flex so children CAN break across pages, kill overflow-x  */
+  .table-responsive,
+  .card-body,
+  .card {
+    display: block !important;
+    overflow: visible !important;
+  }
+
+  /* 2) Tell WeasyPrint that tables may break inside, and rows should not split in half */
+  table {
+    page-break-inside: auto;
+    break-inside: auto;
+  }
+  thead {
+    /* repeat on every page */
+    display: table-header-group;
+  }
+  tfoot {
+    /* repeat on every page if you need footers */
+    display: table-footer-group;
+  }
+  tr {
+    /* don’t slice a row in half */
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  tbody {
+    /* allow breaking between rows */
+    display: table-row-group;
+  }
+</style>
+{% endblock %}
+
+
+{% block title %}
+Department Storage Report
+{% endblock %}
+
+
+{% block content %}
+
+<div id="alert_div">
+</div>
+
+<div class="mb-3">
+  <h2 class="text-justify">{{ department.name }}</h2>
+  <hr>
+</div>
+
+<!-- Start Department Summary -->
+<div class="card mb-3">
+  <div class="card-body">
+    <h3 class="card-title">Department Storage Summary</h3>
+    <p class="card-text text-justify"><strong>Labs in Report: </strong>{{ project_reports|length }}</p>
+    <p class="card-text text-justify"><strong>Total Storage Quota: </strong>{{ department_total.size|floatformat:1 }}</p>
+    <p class="card-text text-justify"><strong>Total Storage Used: </strong>{{ department_total.usage|floatformat:1 }}</p>
+    <p class="card-text text-justify"><strong>Total Monthly Cost: </strong>${{ department_total.cost|floatformat:2 }}</p>
+  </div>
+</div>
+<!-- End Department Summary -->
+
+{% for report in project_reports %}
+<div class="html2pdf__page-break"></div>
+
+<!-- Start Project Heading -->
+<div class="card mb-3">
+  <div class="card-body">
+    <h3 class="card-title">{{ report.project.title }}</h3>
+    <h4 class="card-title">
+      Principal Investigator:
+      {{ report.project.pi.first_name }}
+      {{ report.project.pi.last_name }}
+      ({{ report.project.pi.username }})
+    </h4>
+    <p class="card-text text-justify"><strong>Description: </strong>{{ report.project.description }}</p>
+    <p class="card-text text-justify"><strong>Field of Science: </strong>{{ report.project.field_of_science }}</p>
+    <p class="card-text text-justify"><strong>Project Status: </strong>{{ report.project.status }}</p>
+    <p class="card-text text-justify"><strong>Created: </strong>{{ report.project.created|date:"M. d, Y" }}</p>
+  </div>
+</div>
+<!-- End Project Heading -->
+
+<!-- Start Project Invoice/Allocations -->
+<div class="card mb-3">
+  <div class="card-header">
+    <h4 class="d-inline"><i class="fas fa-list" aria-hidden="true"></i> Storage Allocations</h4>
+    <span class="badge badge-secondary">{{ report.storage_allocations.count }}</span>
+  </div>
+  <div class="card-body">
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th scope="col">Resource Name</th>
+          <th scope="col">Location</th>
+          <th scope="col">Users</th>
+          <th scope="col">Quota</th>
+          <th scope="col">Used</th>
+          <th scope="col">Monthly Cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for allocation in report.storage_allocations %}
+          {% if allocation.status.name == 'Active' %}
+            <tr style="background-color:#FFFFFF">
+              <td>{{ allocation.get_parent_resource.name }}</td>
+              <td>{{ allocation.path }}</td>
+              <td>{{ allocation.allocationuser_set.count }}</td>
+              <td>{{ allocation.size|floatformat:1 }} {{ allocation.get_parent_resource.quantity_label }}</td>
+              <td>{{ allocation.usage|floatformat:1 }}</td>
+              <td>
+                {% if allocation.requires_payment %}
+                  ${{ allocation.cost|floatformat:2}}
+                {% endif %}
+              </td>
+            </tr>
+          {% endif %}
+        {% endfor %}
+      </tbody>
+      {% if report.storage_allocations|length > 1 %}
+        <tfoot>
+          <tr style="background-color:#C2C2C2;font-weight:bold">
+              <td>Total Storage</td>
+              <td></td>
+              <td>{{ report.allocation_total.allocation_user_count }}</td>
+              <td>{{ report.allocation_total.size|floatformat:1}}</td>
+              <td>{{ report.allocation_total.usage|floatformat:1}}</td>
+              <td>${{ report.allocation_total.cost|floatformat:2 }}</td>
+          </tr>
+        </tfoot>
+      {% endif %}
+    </table>
+  </div>
+</div>
+<!-- End Project Invoice/Allocations -->
+
+<!-- Start Project Users -->
+<div class="card mb-3">
+  <div class="card-header">
+    <h4 class="d-inline"><i class="fas fa-users" aria-hidden="true"></i> Users</h4>
+    <span class="badge badge-secondary">{{ report.project_users.count }}</span>
+  </div>
+  <div class="card-body">
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th scope="col">Username</th>
+          <th scope="col">Name</th>
+          <th scope="col">Email</th>
+          <th scope="col" class="text-nowrap">Role</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for user in report.project_users %}
+          <tr>
+            <td>{{ user.user.username }}</td>
+            <td>{{ user.user.first_name }} {{ user.user.last_name }}</td>
+            <td>{{ user.user.email }}</td>
+            <td>{{ user.role.name }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+<!-- End Project Users -->
+
+{% endfor %}
+
+{% endblock %}

--- a/coldfront/core/department/urls.py
+++ b/coldfront/core/department/urls.py
@@ -7,6 +7,9 @@ urlpatterns = [
     path(
         '<int:pk>/', dept_views.DepartmentDetailView.as_view(), name='department-detail'
     ),
+    path(
+        '<int:pk>/report', dept_views.DepartmentStorageReportView.as_view(), name='department-report'
+    ),
     path('<int:pk>/departmentnote/add', dept_views.DepartmentNoteCreateView.as_view(), name='department-note-add'),
     path(
         'department-note/<int:pk>/update',

--- a/coldfront/core/department/views.py
+++ b/coldfront/core/department/views.py
@@ -7,7 +7,9 @@ from django.urls import reverse, reverse_lazy
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django_renderpdf.views import PDFView
 
+from coldfront.core.utils.common import import_from_settings
 from coldfront.core.utils.views import ColdfrontListView, NoteCreateView, NoteUpdateView
 from coldfront.core.allocation.models import Allocation, AllocationUser, AllocationAttributeType
 from coldfront.core.department.forms import DepartmentSearchForm
@@ -265,4 +267,70 @@ class DepartmentDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
             context['ondemand_url'] = settings.ONDEMAND_URL
         except AttributeError:
             pass
+        return context
+
+
+class DepartmentStorageReportView(LoginRequiredMixin, UserPassesTestMixin, PDFView):
+    """Render a department-wide PDF storage report covering every active
+    project (lab) in the department, with full allocation detail per project.
+    """
+
+    template_name = 'department/department_storagereport.html'
+
+    def test_func(self):
+        """UserPassesTestMixin Tests"""
+        if self.request.user.is_superuser:
+            return True
+
+        department_obj = get_object_or_404(Department, pk=self.kwargs.get('pk'))
+        member_permissions = return_department_roles(self.request.user, department_obj)
+        if 'approver' in member_permissions:
+            return True
+
+        err = 'You do not have permission to view the previous page.'
+        messages.error(self.request, err)
+        return False
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        department_obj = get_object_or_404(Department, pk=self.kwargs.get('pk'))
+        projects = department_obj.projects.filter(status__name='Active').order_by('title')
+
+        department_total = {'allocation_user_count': 0, 'size': 0, 'cost': 0, 'usage': 0}
+        project_reports = []
+        for project_obj in projects:
+            project_users = project_obj.projectuser_set.filter(
+                status__name='Active').order_by('user__username')
+            storage_allocations = project_obj.allocation_set.filter(
+                status__name__in=['Active', 'Paid', 'Ready for Review', 'Payment Requested'],
+                resources__resource_type__name='Storage'
+            ).distinct().prefetch_related('resources').order_by('-pk')
+
+            allocation_total = {'allocation_user_count': 0, 'size': 0, 'cost': 0, 'usage': 0}
+            for allocation in storage_allocations:
+                if allocation.cost and allocation.requires_payment:
+                    allocation_total['cost'] += allocation.cost
+                if allocation.size:
+                    allocation_total['size'] += allocation.size
+                if allocation.usage:
+                    allocation_total['usage'] += allocation.usage
+                allocation_total['allocation_user_count'] += int(
+                    allocation.allocationuser_set.count()
+                )
+
+            for key in department_total:
+                department_total[key] += allocation_total[key]
+
+            project_reports.append({
+                'project': project_obj,
+                'storage_allocations': storage_allocations,
+                'allocation_total': allocation_total,
+                'project_users': project_users,
+            })
+
+        context['department'] = department_obj
+        context['project_reports'] = project_reports
+        context['department_total'] = department_total
+        context['CENTER_BASE_URL'] = import_from_settings('CENTER_BASE_URL', '')
         return context

--- a/coldfront/core/department/views.py
+++ b/coldfront/core/department/views.py
@@ -9,7 +9,6 @@ from django.views.generic import DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django_renderpdf.views import PDFView
 
-from coldfront.core.utils.common import import_from_settings
 from coldfront.core.utils.views import ColdfrontListView, NoteCreateView, NoteUpdateView
 from coldfront.core.allocation.models import Allocation, AllocationUser, AllocationAttributeType
 from coldfront.core.department.forms import DepartmentSearchForm
@@ -295,42 +294,40 @@ class DepartmentStorageReportView(LoginRequiredMixin, UserPassesTestMixin, PDFVi
         context = super().get_context_data(**kwargs)
 
         department_obj = get_object_or_404(Department, pk=self.kwargs.get('pk'))
-        projects = department_obj.projects.filter(status__name='Active').order_by('title')
+        project_objs = list(department_obj.projects.filter(status__name='Active'))
 
-        department_total = {'allocation_user_count': 0, 'size': 0, 'cost': 0, 'usage': 0}
-        project_reports = []
-        for project_obj in projects:
-            project_users = project_obj.projectuser_set.filter(
-                status__name='Active').order_by('user__username')
-            storage_allocations = project_obj.allocation_set.filter(
-                status__name__in=['Active', 'Paid', 'Ready for Review', 'Payment Requested'],
-                resources__resource_type__name='Storage'
-            ).distinct().prefetch_related('resources').order_by('-pk')
+        storage_pi_dict = {p.pi: [] for p in project_objs}
+        for p in project_objs:
+            p.storage_allocs = p.allocation_set.filter(
+                resources__resource_type__name='Storage',
+                allocationattribute__allocation_attribute_type__name='RequiresPayment',
+                allocationattribute__value='True',
+                status__name='Active',
+            )
+            storage_pi_dict[p.pi].extend(list(p.storage_allocs))
+        storage_pi_dict = {pi: allocs for pi, allocs in storage_pi_dict.items() if allocs}
+        for pi, allocs in storage_pi_dict.items():
+            pi.storage_total_price = sum(float(a.cost) for a in allocs if a.cost)
 
-            allocation_total = {'allocation_user_count': 0, 'size': 0, 'cost': 0, 'usage': 0}
-            for allocation in storage_allocations:
-                if allocation.cost and allocation.requires_payment:
-                    allocation_total['cost'] += allocation.cost
-                if allocation.size:
-                    allocation_total['size'] += allocation.size
-                if allocation.usage:
-                    allocation_total['usage'] += allocation.usage
-                allocation_total['allocation_user_count'] += int(
-                    allocation.allocationuser_set.count()
-                )
+        storage_alloc_ids = [a.id for allocs in storage_pi_dict.values() for a in allocs]
+        storage_project_ids = {a.project_id for allocs in storage_pi_dict.values() for a in allocs}
 
-            for key in department_total:
-                department_total[key] += allocation_total[key]
+        allocationuser_filter = Q(status__name='Active') & ~Q(usage_bytes__isnull=True)
+        allocation_users = AllocationUser.objects.filter(
+            Q(allocation_id__in=storage_alloc_ids) & allocationuser_filter
+        )
 
-            project_reports.append({
-                'project': project_obj,
-                'storage_allocations': storage_allocations,
-                'allocation_total': allocation_total,
-                'project_users': project_users,
-            })
+        storage_full_price = sum(pi.storage_total_price for pi in storage_pi_dict)
+        detail_table = [
+            ('Department', department_obj.name),
+            ('Total Labs in Bill', len(storage_project_ids)),
+            ('Total Allocations in Bill', len(storage_alloc_ids)),
+            ('Total Users in Bill', allocation_users.count()),
+            ('Service Period', '1 Month'),
+            ('Total Amount Due, Monthly Storage', f'${round(storage_full_price, 2)}'),
+        ]
 
         context['department'] = department_obj
-        context['project_reports'] = project_reports
-        context['department_total'] = department_total
-        context['CENTER_BASE_URL'] = import_from_settings('CENTER_BASE_URL', '')
+        context['storage_pi_dict'] = storage_pi_dict
+        context['detail_table'] = detail_table
         return context

--- a/coldfront/core/project/tasks.py
+++ b/coldfront/core/project/tasks.py
@@ -14,7 +14,7 @@ from coldfront.core.utils.mail import send_email_template, email_template_contex
 TESTUSER = import_from_settings('TESTUSER')
 EMAIL_TICKET_SYSTEM_ADDRESS = import_from_settings('EMAIL_TICKET_SYSTEM_ADDRESS')
 
-DEPARTMENT_REPORT_PROJECT_THRESHOLD = 10
+DEPARTMENT_REPORT_RANKS = ('school', 'institution')
 
 logger = logging.getLogger(__name__)
 
@@ -78,12 +78,10 @@ def send_storagereport_pdf(project, context=None):
 
 def send_dept_storage_report_emails():
     """Send monthly email with department storage reports to departments
-    with more than DEPARTMENT_REPORT_PROJECT_THRESHOLD active projects.
+    with rank of 'school' or 'institution'.
     """
-    for department in Department.objects.all():
-        active_project_count = department.get_projects().filter(status__name='Active').count()
-        if active_project_count > DEPARTMENT_REPORT_PROJECT_THRESHOLD:
-            send_dept_storagereport_pdf(department)
+    for department in Department.objects.filter(rank__in=DEPARTMENT_REPORT_RANKS):
+        send_dept_storagereport_pdf(department)
 
 def send_dept_storagereport_pdf(department, context=None):
     """

--- a/coldfront/core/project/tasks.py
+++ b/coldfront/core/project/tasks.py
@@ -4,6 +4,8 @@ import logging
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 
+from coldfront.core.department.models import Department
+from coldfront.core.department.views import DepartmentStorageReportView
 from coldfront.core.project.models import Project
 from coldfront.core.project.views import ProjectStorageReportView
 from coldfront.core.utils.common import import_from_settings
@@ -11,6 +13,8 @@ from coldfront.core.utils.mail import send_email_template, email_template_contex
 
 TESTUSER = import_from_settings('TESTUSER')
 EMAIL_TICKET_SYSTEM_ADDRESS = import_from_settings('EMAIL_TICKET_SYSTEM_ADDRESS')
+
+DEPARTMENT_REPORT_PROJECT_THRESHOLD = 10
 
 logger = logging.getLogger(__name__)
 
@@ -70,4 +74,60 @@ def send_storagereport_pdf(project, context=None):
         logger.exception(
             'could not send storage report email for project %s to receivers %s from sender %s: %s',
             title, receiver_list, EMAIL_TICKET_SYSTEM_ADDRESS, e
+        )
+
+def send_dept_storage_report_emails():
+    """Send monthly email with department storage reports to departments
+    with more than DEPARTMENT_REPORT_PROJECT_THRESHOLD active projects.
+    """
+    for department in Department.objects.all():
+        active_project_count = department.get_projects().filter(status__name='Active').count()
+        if active_project_count > DEPARTMENT_REPORT_PROJECT_THRESHOLD:
+            send_dept_storagereport_pdf(department)
+
+def send_dept_storagereport_pdf(department, context=None):
+    """
+    Renders the DepartmentStorageReportView to PDF and emails it to the
+    department's approvers. `context` will be passed to the view when rendering.
+    """
+    system_user = get_user_model().objects.get(username=TESTUSER)
+    month = datetime.now().strftime("%B")
+    year = datetime.now().year
+    name = department.name
+    subject = f'Monthly ColdFront Department Storage Report for {name} [{month} {year}]'
+    context = email_template_context(extra_context={
+        'EMAIL_TICKET_SYSTEM_ADDRESS': EMAIL_TICKET_SYSTEM_ADDRESS,
+        'department_name': name,
+    })
+    # 1) build a fake GET request, set any necessary attributes
+    factory = RequestFactory()
+    request = factory.get(f'department/{department.pk}/report')
+    request.user = system_user
+
+    # 2) instantiate and call class‐based view
+    view = DepartmentStorageReportView.as_view()
+    response = view(request, pk=department.pk)
+
+    # 3) make sure the response is rendered and grab the bytes
+    if hasattr(response, 'rendered_content'):
+        pdf_bytes = response.rendered_content
+    else:
+        pdf_bytes = response.content
+
+    approvers = department.members.filter(role="Approver")
+    receiver_list = [approver.user.email for approver in approvers]
+    attachment = (f'{name}_{month}_{year}_dept_storagereport.pdf', pdf_bytes, 'application/pdf')
+    try:
+        send_email_template(
+            subject,
+            'email/dept_storage_report.txt',
+            context,
+            EMAIL_TICKET_SYSTEM_ADDRESS,
+            receiver_list,
+            attachments=(attachment,)
+        )
+    except Exception as e:
+        logger.exception(
+            'could not send department storage report email for department %s to receivers %s from sender %s: %s',
+            name, receiver_list, EMAIL_TICKET_SYSTEM_ADDRESS, e
         )

--- a/coldfront/core/project/tasks.py
+++ b/coldfront/core/project/tasks.py
@@ -92,6 +92,7 @@ def send_dept_storagereport_pdf(department, context=None):
     month = datetime.now().strftime("%B")
     year = datetime.now().year
     name = department.name
+    code = department.code
     subject = f'Monthly ColdFront Department Storage Report for {name} [{month} {year}]'
     context = email_template_context(extra_context={
         'EMAIL_TICKET_SYSTEM_ADDRESS': EMAIL_TICKET_SYSTEM_ADDRESS,
@@ -114,7 +115,7 @@ def send_dept_storagereport_pdf(department, context=None):
 
     approvers = department.members.filter(role="Approver")
     receiver_list = [approver.user.email for approver in approvers]
-    attachment = (f'{name}_{month}_{year}_dept_storagereport.pdf', pdf_bytes, 'application/pdf')
+    attachment = (f'{code}_{month}_{year}_dept_storagereport.pdf', pdf_bytes, 'application/pdf')
     try:
         send_email_template(
             subject,

--- a/coldfront/templates/email/dept_storage_report.txt
+++ b/coldfront/templates/email/dept_storage_report.txt
@@ -1,0 +1,11 @@
+Please review the latest monthly report for {{department_name}}. Included in this report is a list of the labs under your department and the latest usage and limits for each lab's storage allocations.
+
+This is NOT A BILL. This is an informative report generated monthly to ensure the list of users and storage allocations are up to date.
+
+You can login to the Coldfront dashboard for further details using your FASRC account name and password. Please visit the FASRC website if you require a new password or a password reset. We recommend accessing the Coldfront dashboard using the FASRC VPN.
+
+Further questions or concerns should be directed to {{ EMAIL_TICKET_SYSTEM_ADDRESS }}.
+
+Thank you,
+
+{{ signature }}


### PR DESCRIPTION
## Summary

- Add `dept_storage_report.txt` email template with department name, ticket address, and signature variables
- Add `DepartmentStorageReportView` (PDFView) in `department/views.py` gated to superusers and department approvers, rendering a usage summary card and monthly storage invoice details table (matching the DepartmentDetail page, without pagination)
- Add `<int:pk>/report` URL route (`department-report`) in `department/urls.py`
- Add `send_dept_storage_report_emails()` and `send_dept_storagereport_pdf()` to `project/tasks.py` — sends to departments with rank `school` or `institution`, addressed to members with the Approver role

## Test plan

- [x] Navigate to `/department/<pk>/report` as a superuser and confirm PDF renders with usage summary and invoice details table
- [x] Navigate to `/department/<pk>/report` as a department Approver and confirm access is granted
- [x] Navigate to `/department/<pk>/report` as a non-member and confirm 403
- [x] Confirm usage summary counts (labs, allocations, users) only reflect labs with active storage allocations
- [x] Call `send_dept_storage_report_emails()` in the Django shell and confirm emails are sent only for departments with rank `school` or `institution`
- [x] Confirm departments with other ranks are skipped
- [x] Confirm PDF attachment is named `<DeptCode>_<Month>_<Year>_dept_storagereport.pdf`