### PR TITLE
Append actor note to AD info field on user disable/enable

### DIFF
--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -92,6 +92,27 @@ EMAIL_DIRECTOR_EMAIL_ADDRESS = import_from_settings('EMAIL_DIRECTOR_EMAIL_ADDRES
 EMAIL_SENDER = import_from_settings('EMAIL_SENDER')
 EMAIL_TICKET_SYSTEM_ADDRESS = import_from_settings('EMAIL_TICKET_SYSTEM_ADDRESS')
 
+_ROLE_ABBREVIATIONS = {
+    'Principal Investigator': 'PI',
+    'General Manager': 'GM',
+    'Access Manager': 'AM',
+    'Storage Manager': 'SM',
+}
+
+
+def _actor_role_label(actor, project_obj):
+    """Return a short role label for actor on project_obj, for use in AD info notes."""
+    if actor.is_superuser:
+        pu = project_obj.projectuser_set.filter(user=actor).first()
+        if pu:
+            return _ROLE_ABBREVIATIONS.get(pu.role.name, pu.role.name)
+        return 'admin'
+    pu = project_obj.projectuser_set.filter(user=actor).first()
+    if pu:
+        return _ROLE_ABBREVIATIONS.get(pu.role.name, pu.role.name)
+    return 'CF'
+
+
 def produce_filter_parameter(key, value):
     if isinstance(value, list):
         return ''.join([f'{key}={ele}&' for ele in value])
@@ -673,7 +694,7 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
             return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': pk}))
         return super().dispatch(request, *args, **kwargs)
 
-    def reactivate_user(self, project_obj, user_form_data):
+    def reactivate_user(self, project_obj, user_form_data, actor=None):
         """Full organizational logic for user reactivation
         - reactivate projectuser entry
         x reactivate any other projectusers in active projects that still have this user in AD
@@ -686,7 +707,14 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
             user=user_obj,
             status__name='Deactivated'
         ).update(status=ProjectUserStatusChoice.objects.get(name='Active'))
-        project_reactivate_projectuser.send(sender=self.__class__, user=user_obj)
+        actor_username = actor.username if actor else None
+        actor_role = _actor_role_label(actor, project_obj) if actor else None
+        project_reactivate_projectuser.send(
+            sender=self.__class__,
+            user=user_obj,
+            actor_username=actor_username,
+            actor_role=actor_role,
+        )
         AllocationUser.objects.filter(
             user=user_obj,
             allocation__project__status__name__in=['Active', 'Renewal Requested'],
@@ -724,7 +752,7 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                 for form in deactivated_formset:
                     user_form_data = form.cleaned_data
                     if user_form_data['selected']:
-                        self.reactivate_user(project_obj, user_form_data)
+                        self.reactivate_user(project_obj, user_form_data, actor=request.user)
                         messages.success(
                             request, f'Reactivated {user_form_data["username"]}.'
                         )
@@ -1039,7 +1067,10 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
                 try:
                     project_preremove_projectuser.send(
                         sender=self.__class__,
-                        user_name=user_obj.username, group_name=project_obj.title
+                        user_name=user_obj.username,
+                        group_name=project_obj.title,
+                        actor_username=request.user.username,
+                        actor_role=_actor_role_label(request.user, project_obj),
                     )
                     logger.info(
                         'AD group member removed or deactivated.',
@@ -1049,6 +1080,7 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
                             'member': user_obj.username,
                             'group': project_obj.title,
                             'primary_group': user_form_data['primary_group'],
+                            'actor': request.user.username,
                         }
                     )
                 except Exception as e:

--- a/coldfront/plugins/ldap/signals.py
+++ b/coldfront/plugins/ldap/signals.py
@@ -55,8 +55,10 @@ def identify_ad_group(sender, **kwargs):
 def reactivate_user(sender, **kwargs):
     """Reactivate a user in LDAP"""
     user = kwargs['user']
+    actor_username = kwargs.get('actor_username')
+    actor_role = kwargs.get('actor_role')
     ldap_conn = LDAPConn()
-    ldap_conn.reactivate_user(user.username)
+    ldap_conn.reactivate_user(user.username, actor_username=actor_username, actor_role=actor_role)
     ldap_user = ldap_conn.return_user_by_name(user.username)
     user_group_names = [group.split(',')[0].replace('CN=', '') for group in ldap_user['memberOf']]
     projectuser_entries = ProjectUser.objects.filter(
@@ -141,7 +143,12 @@ def add_user_to_group(sender, **kwargs):
 @receiver(project_preremove_projectuser)
 def remove_member_from_group(sender, **kwargs):
     ldap_conn = LDAPConn()
-    ldap_conn.remove_member_from_group(kwargs['user_name'], kwargs['group_name'])
+    ldap_conn.remove_member_from_group(
+        kwargs['user_name'],
+        kwargs['group_name'],
+        actor_username=kwargs.get('actor_username'),
+        actor_role=kwargs.get('actor_role'),
+    )
 
 
 def _fsadm_group_name(project_title):

--- a/coldfront/plugins/ldap/utils.py
+++ b/coldfront/plugins/ldap/utils.py
@@ -298,8 +298,8 @@ class LDAPConn:
 
         Skips the write and logs a warning if the result would exceed AD_INFO_MAX_LENGTH.
         """
-        date_str = datetime.now().strftime('%Y-%m-%d')
-        note = f'\n{date_str} {actor_role} {actor_username} {action} via CF'
+        date_str = datetime.now().strftime('%Y%m%d')
+        note = f'\n{date_str} {actor_username}{actor_role} {action} via CF'
         existing = (current_info[0] if current_info else '') or ''
         new_info = existing + note
         if len(new_info) > self.AD_INFO_MAX_LENGTH:

--- a/coldfront/plugins/ldap/utils.py
+++ b/coldfront/plugins/ldap/utils.py
@@ -246,7 +246,7 @@ class LDAPConn:
         )
         return result
 
-    def remove_member_from_group(self, user_name, group_name):
+    def remove_member_from_group(self, user_name, group_name, actor_username=None, actor_role=None):
         # get group
         group = self.return_group_by_name(group_name)
         # get user
@@ -268,7 +268,7 @@ class LDAPConn:
                     'primary_group_sid': group_sid,
                 }
             )
-            result = self.deactivate_user(member_name)
+            result = self.deactivate_user(member_name, actor_username=actor_username, actor_role=actor_role)
             return result
         try:
             result = ad_remove_members_from_groups(
@@ -291,7 +291,31 @@ class LDAPConn:
         )
         return result
 
-    def deactivate_user(self, username):
+    AD_INFO_MAX_LENGTH = 1024
+
+    def _append_info_note(self, user_dn, current_info, actor_username, actor_role, action):
+        """Append a timestamped note to the AD user's info field.
+
+        Skips the write and logs a warning if the result would exceed AD_INFO_MAX_LENGTH.
+        """
+        date_str = datetime.now().strftime('%Y-%m-%d')
+        note = f'\n{date_str} {actor_role} {actor_username} {action} via CF'
+        existing = (current_info[0] if current_info else '') or ''
+        new_info = existing + note
+        if len(new_info) > self.AD_INFO_MAX_LENGTH:
+            logger.warning(
+                'AD info field would exceed %d chars after appending CF note; skipping write.',
+                self.AD_INFO_MAX_LENGTH,
+                extra={
+                    'category': 'integration:AD',
+                    'actor': actor_username,
+                    'user_dn': user_dn,
+                }
+            )
+            return
+        self.conn.modify(user_dn, {'info': [(MODIFY_REPLACE, [new_info])]})
+
+    def deactivate_user(self, username, actor_username=None, actor_role=None):
         user = self.return_user_by_name(username)
         user_dn = user['distinguishedName']
         filetime_now = now_filetime()
@@ -321,12 +345,14 @@ class LDAPConn:
                 'status': 'success',
                 'username': username,
                 'user_dn': user_dn,
+                'actor': actor_username,
             }
         )
-
+        if actor_username:
+            self._append_info_note(user_dn, user.get('info'), actor_username, actor_role or 'CF', 'disabled')
         return result
 
-    def reactivate_user(self, username):
+    def reactivate_user(self, username, actor_username=None, actor_role=None):
         user = self.return_user_by_name(username)
         user_dn = user['distinguishedName']
         result = self.conn.modify(
@@ -340,6 +366,18 @@ class LDAPConn:
             reason = self.conn.last_error
             logger.error('Failed to reactivate user. username=%s error=%s', username, reason)
             raise LDAPException(f'Failed to reactivate user {username}: {reason}')
+        logger.info(
+            'Reactivated user.',
+            extra={
+                'category': 'integration:AD',
+                'status': 'success',
+                'username': username,
+                'user_dn': user_dn,
+                'actor': actor_username,
+            }
+        )
+        if actor_username:
+            self._append_info_note(user_dn, user.get('info'), actor_username, actor_role or 'CF', 'enabled')
         return result
 
     def users_in_primary_group(self, usernames, groupname):

--- a/coldfront/plugins/ldap/utils.py
+++ b/coldfront/plugins/ldap/utils.py
@@ -313,7 +313,29 @@ class LDAPConn:
                 }
             )
             return
-        self.conn.modify(user_dn, {'info': [(MODIFY_REPLACE, [new_info])]})
+        result = self.conn.modify(user_dn, {'info': [(MODIFY_REPLACE, [new_info])]})
+        if result is False:
+            reason = self.conn.last_error
+            logger.error(
+                'Failed to append info note to user.',
+                extra={
+                    'category': 'integration:AD',
+                    'status': 'failure',
+                    'user_dn': user_dn,
+                    'error': reason,
+                }
+            )
+        else:
+            logger.info(
+                'Appended info note to user.',
+                extra={
+                    'category': 'integration:AD',
+                    'status': 'success',
+                    'user_dn': user_dn,
+                    'actor': actor_username,
+                }
+            )
+
 
     def deactivate_user(self, username, actor_username=None, actor_role=None):
         user = self.return_user_by_name(username)


### PR DESCRIPTION
## Summary

- Add `_append_info_note()` to `LDAPConn` in `ldap/utils.py` — reads the current AD `info` field, appends `\nYYYY-MM-DD <role> <username> disabled/enabled via CF`, and writes back; skips and logs a warning if the result would exceed 1024 characters
- Update `deactivate_user()` and `reactivate_user()` on `LDAPConn` to accept optional `actor_username`/`actor_role` and call `_append_info_note` after a successful operation
- Update `remove_member_from_group()` on `LDAPConn` to forward actor params to `deactivate_user`
- Thread actor info through `project_preremove_projectuser` and `project_reactivate_projectuser` signal sends in `project/views.py` and their receivers in `ldap/signals.py`
- Add `_actor_role_label()` helper in `project/views.py` to map full role names to short labels (PI, GM, AM, SM) for the note

## Test plan

- [ ] Remove a user from their primary group as a PI and confirm the AD `info` field gains a line like `2026-06-17 PI mmcfee disabled via CF`
- [ ] Reactivate that user as a GM and confirm `info` gains `2026-06-17 GM msyed enabled via CF`
- [ ] Pad a test user's `info` field to near 1024 chars and confirm disable is still applied but the note write is skipped with a warning log entry
- [ ] Remove a non-primary-group user and confirm `info` is unchanged (no note appended for plain group removal)
- [ ] Confirm existing `info` content is preserved (append, not replace)