### PR TITLE
add python package specifications to improve build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,13 @@ COPY etc/ipython_init.py ${IPYTHON_STARTUP}
 
 
 RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+    if [ "${BUILD_ENV}" = "dev" ]; then \
+        pip install -r requirements.txt django-redis==5.3.0 django-debug-toolbar==6.3.0; \
+    else \
+        pip install -r requirements.txt; \
+    fi
 
 RUN pip install django-prometheus gunicorn
-
-RUN if [ "${BUILD_ENV}" = "dev" ]; then pip install django-redis django-debug-toolbar; fi
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,6 @@ RUN pip install --upgrade pip && \
         pip install -r requirements.txt; \
     fi
 
-RUN pip install django-prometheus gunicorn
-
 COPY . .
 
 ENV PYTHONPATH /usr/src/app:/usr/src/app/ifxreport:/usr/src/app/ifxbilling:/usr/src/app/fiine.client:/usr/src/app/ifxurls:/usr/src/app/nanites.client:/usr/src/app/ifxuser:/usr/src/app/ifxmail.client:/usr/src/app/ifxec

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ python-dateutil==2.9.0.post0
 python-memcached==1.62
 pytz==2024.1
 redis==5.0.0
-requests==2.32.0
+requests==2.33.0
 six==1.16.0
 sqlparse==0.5.0
 text-unidecode==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,8 @@ XlsxWriter
 git+https://github.com/fasrc/slurmrest_python_sdk.git
 git+https://github.com/fasrc/sftocf.git
 vastpy
+django-prometheus
+gunicorn
 # the following packages are dependencies. Versions are listed to cut down on build time and may be updated as needed
 cryptography==45.0.7
 pydantic==2.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,7 @@ XlsxWriter
 git+https://github.com/fasrc/slurmrest_python_sdk.git
 git+https://github.com/fasrc/sftocf.git
 vastpy
+# the following packages are dependencies. Versions are listed to cut down on build time and may be updated as needed
+cryptography==45.0.7
+pydantic==2.9.2
+svglib==1.5.1


### PR DESCRIPTION
Pinning dependency requirements and combining dev pip installs reduce dev build time by 40 seconds.