### PR TITLE
Prevent deactivated users from being added to projects

### DIFF
--- a/coldfront/core/project/exceptions.py
+++ b/coldfront/core/project/exceptions.py
@@ -1,0 +1,14 @@
+"""Exceptions raised when integrations (e.g. LDAP) reject a project-user change.
+
+Plugins that hook into project signals (see coldfront.core.project.signals) should
+raise these -- or subclasses of these -- rather than plugin-specific exception types,
+so core code can handle the failure without importing from any plugin.
+"""
+
+
+class ProjectUserAdditionError(Exception):
+    """Raised when a user cannot be added to a project by a signal receiver."""
+
+
+class ProjectUserDeactivatedError(ProjectUserAdditionError):
+    """Raised when a user cannot be added to a project because their account is deactivated."""

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -66,6 +66,7 @@ from coldfront.core.project.models import (
 )
 from coldfront.core.project.manager_role_notifications import notify_manager_role_transition
 from coldfront.core.project.utils import generate_usage_history_graph
+from coldfront.core.project.exceptions import ProjectUserDeactivatedError
 from coldfront.core.publication.models import Publication
 from coldfront.core.research_output.models import ResearchOutput
 from coldfront.core.resource.models import ResourceAttribute
@@ -833,6 +834,12 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                             sender=self.__class__,
                             user_name=user_obj.username, group_name=project_obj.title
                         )
+                    except ProjectUserDeactivatedError:
+                        errors.append(
+                            f"Could not add user {user_obj} to project {project_obj.title}: "
+                            "this user's account is deactivated."
+                        )
+                        continue
                     except Exception as e:
                         logger.exception(
                             'AD user addition to group failed.',

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -638,6 +638,14 @@ class ProjectAddUsersSearchResultsView(
         context = combined_user_search_obj.search()
 
         matches = context.get('matches')
+        inactive_usernames = set(
+            get_user_model().objects.filter(
+                username__in=[match['username'] for match in matches],
+                is_active=False,
+            ).values_list('username', flat=True)
+        )
+        matches = [match for match in matches if match['username'] not in inactive_usernames]
+        context['matches'] = matches
         for match in matches:
             match.update({'role': ProjectUserRoleChoice.objects.get(name='User')})
 

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -639,14 +639,6 @@ class ProjectAddUsersSearchResultsView(
         context = combined_user_search_obj.search()
 
         matches = context.get('matches')
-        inactive_usernames = set(
-            get_user_model().objects.filter(
-                username__in=[match['username'] for match in matches],
-                is_active=False,
-            ).values_list('username', flat=True)
-        )
-        matches = [match for match in matches if match['username'] not in inactive_usernames]
-        context['matches'] = matches
         for match in matches:
             match.update({'role': ProjectUserRoleChoice.objects.get(name='User')})
 

--- a/coldfront/plugins/ldap/signals.py
+++ b/coldfront/plugins/ldap/signals.py
@@ -19,7 +19,7 @@ from coldfront.core.project.models import (
     ProjectUserStatusChoice,
     ProjectUser,
 )
-from coldfront.plugins.ldap.utils import LDAPConn
+from coldfront.plugins.ldap.utils import LDAPConn, LDAPUserDeactivatedError
 
 if 'sftocf' in import_from_settings('INSTALLED_APPS', []):
     from sftocf.signals import (
@@ -138,7 +138,19 @@ def filter_project_users_to_remove(sender, **kwargs):
 @receiver(project_make_projectuser)
 def add_user_to_group(sender, **kwargs):
     ldap_conn = LDAPConn()
-    ldap_conn.add_user_to_group(kwargs['user_name'], kwargs['group_name'])
+    try:
+        ldap_conn.add_user_to_group(kwargs['user_name'], kwargs['group_name'])
+    except LDAPUserDeactivatedError:
+        logger.warning(
+            'Cannot add deactivated user to AD group.',
+            extra={
+                'category': 'ldap:GroupMembership',
+                'status': 'error',
+                'user': kwargs['user_name'],
+                'group': kwargs['group_name'],
+            }
+        )
+        raise
 
 @receiver(project_preremove_projectuser)
 def remove_member_from_group(sender, **kwargs):

--- a/coldfront/plugins/ldap/utils.py
+++ b/coldfront/plugins/ldap/utils.py
@@ -32,6 +32,7 @@ from coldfront.core.project.models import (
     ProjectUserStatusChoice,
     ProjectUser,
 )
+from coldfront.core.project.exceptions import ProjectUserDeactivatedError
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,9 @@ class LDAPException(Exception):
 
 class LDAPUserAdditionError(LDAPException):
     """An exception raised when a user cannot be added to an LDAP Group"""
+
+class LDAPUserDeactivatedError(LDAPUserAdditionError, ProjectUserDeactivatedError):
+    """An exception raised when a user cannot be added to an LDAP Group because their account is deactivated"""
 
 class LDAPUserRemovalError(LDAPException):
     """An exception raised when a user cannot be removed from an LDAP Group"""
@@ -211,6 +215,10 @@ class LDAPConn:
 
     def add_user_to_group(self, user_name, group_name):
         user = self.return_user_by_name(user_name)
+        if not user_valid(user):
+            raise LDAPUserDeactivatedError(
+                f"Cannot add user {user_name} to group {group_name}: user is deactivated."
+            )
         group = self.return_group_by_name(group_name)
         self.add_member_to_group(user, group)
 


### PR DESCRIPTION
## Summary

- Filter `ProjectAddUsersSearchResultsView` search results to exclude users whose local Django account has `is_active=False`, so deactivated accounts don't surface as addable matches — LDAP-only users with no local record yet are unaffected.
- Raise `ProjectUserDeactivatedError` from `LDAPConn.add_user_to_group` when the target AD account's `userAccountControl` marks it deactivated, closing the gap where a deactivated user could still be added directly by username.
- Define the new exception in `coldfront.core.project.exceptions` (not the LDAP plugin) so core code never imports from a plugin — the LDAP plugin's `LDAPUserDeactivatedError` subclasses it instead.
- Log and re-raise the error in the `project_make_projectuser` signal receiver, and catch it in `ProjectAddUsersView` to show the requester a specific "this user's account is deactivated" message instead of the generic AD-failure message.

## Test plan

- [x] Search for a project-add-user candidate whose account is deactivated and confirm they no longer appear in search results
- [x] Attempt to add a deactivated user directly (bypassing search, e.g. via form resubmission) and confirm the view shows "this user's account is deactivated" rather than the generic AD error
- [ ] Add an active, non-deactivated user and confirm the normal add flow still succeeds
- [x] Run `coldfront.core.project`, `coldfront.plugins.ldap`, and `coldfront.core.user` test suites and confirm no new failures beyond the pre-existing `coldfront_notifications/navbar.html` template issue