### PR TITLE
Add PI/manager actions to pending allocation request detail page

### DIFF
--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -501,7 +501,7 @@ class AllocationRequestPIActionsForm(forms.Form):
 
     def clean_quantity(self):
         quantity = self.cleaned_data['quantity']
-        if self._resource and self._resource.name == 'Tape' and quantity % 20 != 0:
+        if self._resource and 'tape' in self._resource.name.lower() and quantity % 20 != 0:
             raise forms.ValidationError('Tape quantity must be a multiple of 20.')
         return quantity
 

--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -486,6 +486,16 @@ class AllocationChangeNoteForm(forms.Form):
             help_text='Leave any feedback about the allocation change request.')
 
 
+class AllocationRequestPIActionsForm(forms.Form):
+    """Form for PIs/managers to update the requested size of a pending allocation request."""
+    quantity = forms.IntegerField(
+        label='Requested Size',
+        min_value=1,
+        required=True,
+        help_text='Enter the new requested size in the allocation\'s unit.',
+    )
+
+
 class AllocationChangePIUpdateForm(forms.Form):
     """Form for PIs/managers to update the requested new value of an attribute change."""
     change_pk = forms.IntegerField(required=True, disabled=True)

--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -512,17 +512,31 @@ class AllocationChangePIUpdateForm(forms.Form):
     name = forms.CharField(max_length=150, required=False, disabled=True)
     new_value = forms.CharField(max_length=150, required=False)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, resource=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['change_pk'].widget = forms.HiddenInput()
+        self._resource = resource
 
     def clean(self):
         cleaned_data = super().clean()
-        if cleaned_data.get('new_value') != '':
+        new_value = cleaned_data.get('new_value', '')
+        if new_value != '':
             from coldfront.core.allocation.models import AllocationAttributeChangeRequest
             attr_change = AllocationAttributeChangeRequest.objects.get(pk=cleaned_data.get('change_pk'))
-            attr_change.allocation_attribute.value = cleaned_data.get('new_value')
+            attr_change.allocation_attribute.value = new_value
             attr_change.allocation_attribute.clean()
+
+            attr_name = attr_change.allocation_attribute.allocation_attribute_type.name
+            if (
+                self._resource
+                and self._resource.name == 'Tape'
+                and 'Storage Quota' in attr_name
+            ):
+                try:
+                    if int(float(new_value)) % 20 != 0:
+                        raise forms.ValidationError('Tape quantity must be a multiple of 20.')
+                except (ValueError, TypeError):
+                    raise forms.ValidationError('Tape quantity must be a whole number.')
 
 
 ALLOCATION_AUTOUPDATE_OPTIONS = [

--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -492,8 +492,18 @@ class AllocationRequestPIActionsForm(forms.Form):
         label='Requested Size',
         min_value=1,
         required=True,
-        help_text='Enter the new requested size in the allocation\'s unit.',
+        help_text="Enter the new requested size in the allocation's unit.",
     )
+
+    def __init__(self, *args, resource=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._resource = resource
+
+    def clean_quantity(self):
+        quantity = self.cleaned_data['quantity']
+        if self._resource and self._resource.name == 'Tape' and quantity % 20 != 0:
+            raise forms.ValidationError('Tape quantity must be a multiple of 20.')
+        return quantity
 
 
 class AllocationChangePIUpdateForm(forms.Form):

--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -529,7 +529,7 @@ class AllocationChangePIUpdateForm(forms.Form):
             attr_name = attr_change.allocation_attribute.allocation_attribute_type.name
             if (
                 self._resource
-                and self._resource.name == 'Tape'
+                and 'tape' in self._resource.name.lower()
                 and 'Storage Quota' in attr_name
             ):
                 try:

--- a/coldfront/core/allocation/management/commands/add_allocation_defaults.py
+++ b/coldfront/core/allocation/management/commands/add_allocation_defaults.py
@@ -29,6 +29,7 @@ class Command(BaseCommand):
             ('In Progress', 'Allocation request is being processed'),
             ('On Hold', 'Allocation request is on hold'),
             ('Pending Activation', 'Allocation is in the process of being set up and not yet ready for use/billing'),
+            ('Withdrawn', 'Allocation request was withdrawn by the PI or manager'),
             # UBCCR Defaults
             # 'Paid', 'Payment Pending', 'Payment Requested',
             # 'Payment Declined', 'Revoked', 'Renewal Requested', 'Unpaid',

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -329,6 +329,41 @@ Allocation Detail
   </div>
 </div>
 
+{% if is_manager and allocation.status.name in 'New,In Progress,On Hold,Pending Activation' %}
+<div class="card mb-3">
+  <div class="card-header">
+    <h3 class="d-inline"><i class="fas fa-edit" aria-hidden="true"></i> Actions</h3>
+  </div>
+  <div class="card-body">
+    <form method="post" action="{% url 'allocation-request-pi-actions' allocation.pk %}">
+      {% csrf_token %}
+      {% if pi_actions_form %}
+        <div class="form-group row align-items-center mb-3">
+          <label class="col-sm-3 col-form-label font-weight-bold">
+            {{ pi_actions_form.quantity.label }}
+            {% if allocation.unit_label %}({{ allocation.unit_label }}){% endif %}
+          </label>
+          <div class="col-sm-3">
+            {{ pi_actions_form.quantity }}
+          </div>
+          <div class="col-sm-6 text-muted small">{{ pi_actions_form.quantity.help_text }}</div>
+        </div>
+      {% endif %}
+      <div class="d-flex justify-content-end">
+        {% if pi_actions_form %}
+          <button type="submit" name="pi_action" value="update_size" class="btn btn-primary mr-2">
+            <i class="fas fa-save" aria-hidden="true"></i> Update Requested Size
+          </button>
+        {% endif %}
+        <button type="submit" name="pi_action" value="withdraw"
+                class="btn btn-danger confirm-withdraw-request">
+          <i class="fas fa-times" aria-hidden="true"></i> Withdraw Request
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endif %}
 
 <div class="html2pdf__page-break"></div>
 {% if attributes or attributes_with_usage or user_can_manage_allocation %}
@@ -849,6 +884,9 @@ Allocation Detail
         if (notes_num == 0) {
             return confirm('Are you sure you want to deny this allocation request without setting a notification?');
         }
+    })
+    $(document).on('click', '.confirm-withdraw-request', function(){
+        return confirm('Are you sure you want to withdraw this allocation request?');
     })
 </script>
 {% endblock %}

--- a/coldfront/core/allocation/urls.py
+++ b/coldfront/core/allocation/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [
          name='allocation-change-detail'),
     path('change-request/<int:pk>/pi-actions', allocation_views.AllocationChangePIActionsView.as_view(),
          name='allocation-change-pi-actions'),
+    path('<int:pk>/pi-actions', allocation_views.AllocationRequestPIActionsView.as_view(),
+         name='allocation-request-pi-actions'),
     path('<int:pk>/delete-attribute-change', allocation_views.AllocationChangeDeleteAttributeView.as_view(),
          name='allocation-attribute-change-delete'),
     path('<int:pk>/add-users', allocation_views.AllocationAddUsersView.as_view(),

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -38,6 +38,7 @@ from coldfront.core.allocation.forms import (AllocationAccountForm,
                                              AllocationChangeForm,
                                              AllocationChangeNoteForm,
                                              AllocationChangePIUpdateForm,
+                                             AllocationRequestPIActionsForm,
                                              AllocationAttributeChangeForm,
                                              AllocationAttributeUpdateForm,
                                              AllocationForm,
@@ -325,6 +326,15 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
 
         context['form'] = form
         context['allocation'] = allocation_obj
+
+        if allocation_obj.status.name in PENDING_ALLOCATION_STATUSES:
+            is_manager = allocation_obj.has_perm(request.user, AllocationPermission.MANAGER)
+            context['is_manager'] = is_manager
+            if is_manager:
+                context['pi_actions_form'] = AllocationRequestPIActionsForm(
+                    initial={'quantity': allocation_obj.quantity or 1}
+                )
+
         return self.render_to_response(context)
 
     def post(self, request, *args, **kwargs):
@@ -2302,6 +2312,72 @@ class AllocationAccountListView(LoginRequiredMixin, UserPassesTestMixin, ListVie
 
     def get_queryset(self):
         return AllocationAccount.objects.filter(user=self.request.user)
+
+
+class AllocationRequestPIActionsView(LoginRequiredMixin, UserPassesTestMixin, View):
+    """Allows PIs, Storage Managers, and General Managers to update the requested size
+    of a pending allocation request or withdraw it entirely."""
+
+    def test_func(self):
+        allocation_obj = get_object_or_404(Allocation, pk=self.kwargs.get('pk'))
+        return allocation_obj.has_perm(self.request.user, AllocationPermission.MANAGER)
+
+    def post(self, request, *args, **kwargs):
+        pk = self.kwargs.get('pk')
+        allocation_obj = get_object_or_404(Allocation, pk=pk)
+        redirect_url = reverse('allocation-detail', kwargs={'pk': pk})
+
+        if allocation_obj.status.name not in PENDING_ALLOCATION_STATUSES:
+            messages.error(request, 'This allocation request is no longer pending and cannot be modified.')
+            return HttpResponseRedirect(redirect_url)
+
+        action = request.POST.get('pi_action')
+        if action not in ['update_size', 'withdraw']:
+            return HttpResponseBadRequest('Invalid request')
+
+        if action == 'withdraw':
+            withdrawn_status = AllocationStatusChoice.objects.get(name='Withdrawn')
+            allocation_obj.status = withdrawn_status
+            allocation_obj.save()
+            messages.success(request, 'Allocation request has been withdrawn.')
+            return HttpResponseRedirect(redirect_url)
+
+        # action == 'update_size'
+        form = AllocationRequestPIActionsForm(request.POST)
+        if not form.is_valid():
+            for err in form.errors.values():
+                messages.error(request, err)
+            return HttpResponseRedirect(redirect_url)
+
+        new_quantity = form.cleaned_data['quantity']
+
+        if allocation_obj.get_parent_resource.name == 'Tape' and new_quantity % 20 != 0:
+            messages.error(request, 'Tape quantity must be a multiple of 20.')
+            return HttpResponseRedirect(redirect_url)
+
+        unit_label = allocation_obj.unit_label
+        conversion_factor = 1000 if unit_label == 'TB' else 1024
+        quota_in_bytes = new_quantity * (conversion_factor ** 4)
+
+        allocation_obj.quantity = new_quantity
+        allocation_obj.save()
+
+        quota_attr = allocation_obj.allocationattribute_set.filter(
+            allocation_attribute_type__name=f'Storage Quota ({unit_label})'
+        ).first()
+        if quota_attr:
+            quota_attr.value = new_quantity
+            quota_attr.save()
+
+        bytes_attr = allocation_obj.allocationattribute_set.filter(
+            allocation_attribute_type__name='Quota_In_Bytes'
+        ).first()
+        if bytes_attr:
+            bytes_attr.value = quota_in_bytes
+            bytes_attr.save()
+
+        messages.success(request, f'Requested size updated to {new_quantity} {unit_label}.')
+        return HttpResponseRedirect(redirect_url)
 
 
 class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormView):

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -2463,7 +2463,8 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
                     }
                     for a in attr_changes
                 ]
-                pi_formset_class = formset_factory(AllocationChangePIUpdateForm, max_num=len(pi_initial))
+                resource = allocation_change_obj.allocation.get_parent_resource
+                pi_formset_class = formset_factory(_make_pi_update_form(resource), max_num=len(pi_initial))
                 context['pi_formset'] = pi_formset_class(initial=pi_initial, prefix='pi_attributeform')
 
         return render(request, self.template_name, context)
@@ -2679,6 +2680,11 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
         return self.redirect_to_detail(pk)
 
 
+def _make_pi_update_form(resource):
+    """Return a subclass of AllocationChangePIUpdateForm bound to the given resource."""
+    return type('BoundAllocationChangePIUpdateForm', (AllocationChangePIUpdateForm,), {'_resource': resource})
+
+
 class AllocationChangePIActionsView(LoginRequiredMixin, UserPassesTestMixin, View):
     """Allows PIs, Storage Managers, and General Managers to update or cancel a pending change request."""
 
@@ -2713,7 +2719,8 @@ class AllocationChangePIActionsView(LoginRequiredMixin, UserPassesTestMixin, Vie
             alloc_change_obj.allocationattributechangerequest_set.all()
         )
         if attrs_to_change:
-            formset_class = formset_factory(AllocationChangePIUpdateForm, max_num=len(attrs_to_change))
+            resource = alloc_change_obj.allocation.get_parent_resource
+            formset_class = formset_factory(_make_pi_update_form(resource), max_num=len(attrs_to_change))
             initial = [
                 {
                     'change_pk': a.pk,

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -332,7 +332,8 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             context['is_manager'] = is_manager
             if is_manager:
                 context['pi_actions_form'] = AllocationRequestPIActionsForm(
-                    initial={'quantity': allocation_obj.quantity or 1}
+                    initial={'quantity': allocation_obj.quantity or 1},
+                    resource=allocation_obj.get_parent_resource,
                 )
 
         return self.render_to_response(context)
@@ -2343,17 +2344,13 @@ class AllocationRequestPIActionsView(LoginRequiredMixin, UserPassesTestMixin, Vi
             return HttpResponseRedirect(redirect_url)
 
         # action == 'update_size'
-        form = AllocationRequestPIActionsForm(request.POST)
+        form = AllocationRequestPIActionsForm(request.POST, resource=allocation_obj.get_parent_resource)
         if not form.is_valid():
             for err in form.errors.values():
                 messages.error(request, err)
             return HttpResponseRedirect(redirect_url)
 
         new_quantity = form.cleaned_data['quantity']
-
-        if allocation_obj.get_parent_resource.name == 'Tape' and new_quantity % 20 != 0:
-            messages.error(request, 'Tape quantity must be a multiple of 20.')
-            return HttpResponseRedirect(redirect_url)
 
         unit_label = allocation_obj.unit_label
         conversion_factor = 1000 if unit_label == 'TB' else 1024

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -233,6 +233,101 @@ Project Detail
 <!-- End Project Invoice/Allocations -->
 
 
+<!-- Start Pending Allocation Requests -->
+{% if pending_allocation_requests %}
+<div class="html2pdf__page-break"></div>
+<div class="card mb-3">
+  <div class="card-header">
+    <h3 class="d-inline"><i class="fas fa-clock" aria-hidden="true"></i> Pending Allocation Requests</h3>
+    <span class="badge badge-warning">{{ pending_allocation_requests.count }}</span>
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+      <table class="table table-bordered table-sm">
+        <thead>
+          <tr>
+            <th scope="col">Resource</th>
+            <th scope="col">Requested Size</th>
+            <th scope="col">Status</th>
+            <th scope="col">Date Requested</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for allocation in pending_allocation_requests %}
+            <tr>
+              <td>{{ allocation.get_parent_resource }}</td>
+              <td>
+                {% if allocation.quantity and allocation.unit_label %}
+                  {{ allocation.quantity }} {{ allocation.unit_label }}
+                {% else %}
+                  —
+                {% endif %}
+              </td>
+              <td>{{ allocation.status }}</td>
+              <td>{{ allocation.created|date:"M. d, Y" }}</td>
+              <td>
+                <a href="{% url 'allocation-detail' allocation.pk %}" class="btn btn-sm btn-primary">Details</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endif %}
+<!-- End Pending Allocation Requests -->
+
+
+<!-- Start Pending Allocation Change Requests -->
+{% if pending_change_requests %}
+<div class="card mb-3">
+  <div class="card-header">
+    <h3 class="d-inline"><i class="fas fa-exchange-alt" aria-hidden="true"></i> Pending Allocation Change Requests</h3>
+    <span class="badge badge-warning">{{ pending_change_requests.count }}</span>
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+      <table class="table table-bordered table-sm">
+        <thead>
+          <tr>
+            <th scope="col">Resource</th>
+            <th scope="col">Requested Change</th>
+            <th scope="col">Date Requested</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for change_request in pending_change_requests %}
+            <tr>
+              <td>{{ change_request.allocation.get_parent_resource }}</td>
+              <td>
+                {% for attr_change in change_request.allocationattributechangerequest_set.all %}
+                  {{ attr_change.allocation_attribute.allocation_attribute_type.name }}: {{ attr_change.new_value }}<br>
+                {% empty %}
+                  {% if change_request.end_date_extension %}
+                    End date extension: {{ change_request.end_date_extension }} days
+                  {% else %}
+                    —
+                  {% endif %}
+                {% endfor %}
+              </td>
+              <td>{{ change_request.created|date:"M. d, Y" }}</td>
+              <td>
+                <a href="{% url 'allocation-change-detail' change_request.pk %}" class="btn btn-sm btn-primary">Details</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endif %}
+<!-- End Pending Allocation Change Requests -->
+
+
 <!-- Start Allocations -->
 <div class="html2pdf__page-break"></div>
 <div class="card mb-3">

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -295,13 +295,19 @@ Project Detail
             <th scope="col">Resource</th>
             <th scope="col">Requested Change</th>
             <th scope="col">Date Requested</th>
-            <th scope="col">Actions</th>
+            {% if request.user.is_superuser or is_allowed_to_update_project %}
+              <th scope="col">Actions</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody>
           {% for change_request in pending_change_requests %}
             <tr>
-              <td>{{ change_request.allocation.get_parent_resource }}</td>
+              <td>
+                <a href="{% url 'allocation-detail' change_request.allocation.pk %}">
+                  {{ change_request.allocation.get_parent_resource }}
+                </a>
+              </td>
               <td>
                 {% for attr_change in change_request.allocationattributechangerequest_set.all %}
                   {{ attr_change.allocation_attribute.allocation_attribute_type.name }}: {{ attr_change.new_value }}<br>
@@ -314,9 +320,11 @@ Project Detail
                 {% endfor %}
               </td>
               <td>{{ change_request.created|date:"M. d, Y" }}</td>
-              <td>
-                <a href="{% url 'allocation-change-detail' change_request.pk %}" class="btn btn-sm btn-primary">Details</a>
-              </td>
+              {% if request.user.is_superuser or is_allowed_to_update_project %}
+                <td>
+                  <button href="{% url 'allocation-change-detail' change_request.pk %}" class="btn btn-sm btn-primary">Details</button>
+                </td>
+              {% endif %}
             </tr>
           {% endfor %}
         </tbody>

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -267,7 +267,7 @@ Project Detail
               <td>{{ allocation.status }}</td>
               <td>{{ allocation.created|date:"M. d, Y" }}</td>
               <td>
-                <a href="{% url 'allocation-detail' allocation.pk %}" class="btn btn-sm btn-primary">Details</a>
+                <button href="{% url 'allocation-detail' allocation.pk %}" class="btn btn-sm btn-primary">Details</button>
               </td>
             </tr>
           {% endfor %}

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -22,6 +22,7 @@ from django_renderpdf.views import PDFView
 from coldfront.core.allocation.utils import generate_guauge_data_from_usage
 from coldfront.core.allocation.models import (
     Allocation,
+    AllocationChangeRequest,
     AllocationUser,
     AllocationStatusChoice,
     AllocationUserStatusChoice,
@@ -86,6 +87,8 @@ ALLOCATION_ENABLE_ALLOCATION_RENEWAL = import_from_settings(
     'ALLOCATION_ENABLE_ALLOCATION_RENEWAL', True)
 ALLOCATION_DEFAULT_ALLOCATION_LENGTH = import_from_settings(
     'ALLOCATION_DEFAULT_ALLOCATION_LENGTH', 365)
+PENDING_ALLOCATION_STATUSES = import_from_settings(
+    'PENDING_ALLOCATION_STATUSES', ['New', 'In Progress', 'On Hold', 'Pending Activation'])
 
 
 EMAIL_DIRECTOR_EMAIL_ADDRESS = import_from_settings('EMAIL_DIRECTOR_EMAIL_ADDRESS')
@@ -306,6 +309,20 @@ class ProjectDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
         context['storage_allocations'] = storage_allocations
         context['compute_allocations'] = compute_allocations
         context['allocation_total'] = allocation_total
+
+        pending_allocation_requests = self.object.allocation_set.filter(
+            status__name__in=PENDING_ALLOCATION_STATUSES
+        ).prefetch_related('resources').order_by('-created')
+        context['pending_allocation_requests'] = pending_allocation_requests
+
+        pending_change_requests = AllocationChangeRequest.objects.filter(
+            allocation__project=self.object,
+            status__name='Pending',
+        ).select_related('allocation', 'status').prefetch_related(
+            'allocation__resources',
+            'allocationattributechangerequest_set__allocation_attribute__allocation_attribute_type',
+        ).order_by('-created')
+        context['pending_change_requests'] = pending_change_requests
         context['attributes'] = attributes
         context['guage_data'] = guage_data
         context['attributes_with_usage'] = attributes_with_usage


### PR DESCRIPTION
## Summary

- Add `Withdrawn` to `AllocationStatusChoice` defaults for PI-initiated cancellations (distinct from admin `Denied`)
- Add `AllocationRequestPIActionsForm` with a validated `quantity` field
- Add `AllocationRequestPIActionsView` (POST-only, gated to `AllocationPermission.MANAGER`) handling two actions:
  - `update_size` — updates `allocation.quantity`, the `Storage Quota ({unit_label})` attribute, and `Quota_In_Bytes`; validates Tape multiples-of-20 rule
  - `withdraw` — sets allocation status to `Withdrawn` and redirects to allocation detail
- Add `allocation-request-pi-actions` URL route at `<pk>/pi-actions`
- Pass `is_manager` and `pi_actions_form` from `AllocationDetailView.get()` when the allocation is in a pending status
- Show "Actions" card on allocation detail page for managers when the request is pending (New, In Progress, On Hold, Pending Activation)

## Test plan

- [x] As a PI with a pending allocation request, visit the allocation detail page and confirm the Actions card appears
- [x] Update the requested size and confirm `allocation.quantity` and both quota attributes update correctly
- [x] Withdraw the request and confirm status becomes `Withdrawn` and the Actions card disappears
- [x] Confirm the Tape multiples-of-20 validation fires on update
- [x] As a superuser, confirm the Actions card also appears (superusers have MANAGER on all allocations)
- [ ] As a regular project user (non-manager), confirm the Actions card does not appear
- [x] Confirm the Actions card does not appear for non-pending allocations (Active, Denied, Expired, etc.)