### PR TITLE
Add sync_vast_allocations management command

### DIFF
--- a/coldfront/config/plugins/vast.py
+++ b/coldfront/config/plugins/vast.py
@@ -7,5 +7,6 @@ VASTTOKEN = ENV.str('VASTTOKEN', default=None)
 VASTADDRESS = ENV.str('VASTADDRESS', default=None)
 VASTAPI = ENV.str('VASTAPI', default='v6')
 VASTAUTHORIZER = ENV.str('VASTAUTHORIZER', default='AD')
+VAST_PATH_IGNORE = ENV.list('VAST_PATH_IGNORE', default=[])
 
 INSTALLED_APPS += [ 'coldfront.plugins.vast' ]

--- a/coldfront/plugins/fasrc_monitoring/views.py
+++ b/coldfront/plugins/fasrc_monitoring/views.py
@@ -56,11 +56,13 @@ class MonitorView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         pi_not_projectuser = [p for p in projects if p.pi_id not in  p.projectuser_set.values_list('user_id', flat=True)]
         allocation_not_changeable = Allocation.objects.filter(
             status__name__in=PENDING_ACTIVE_ALLOCATION_STATUSES, is_changeable=False,
-            resources__is_allocatable=True
+            resources__is_allocatable=True, resources__resource_type__name='Storage',
         )
-        multiple_allocation_resources = Allocation.objects.annotate(
-            num_vols=Count('resources')
-        ).filter(num_vols__gte=2)
+        multiple_allocation_resources = (
+            Allocation.objects.filter(resources__resource_type__name='Storage').annotate(
+                num_vols=Count('resources')
+            ).filter(num_vols__gte=2)
+        )
 
         # ui checks
         ui_error_file = 'local_data/error_checks.csv'

--- a/coldfront/plugins/isilon/utils.py
+++ b/coldfront/plugins/isilon/utils.py
@@ -680,6 +680,7 @@ def sync_allocation_for_quota(project, resource, directory_quota, report):
         project=project,
         status=AllocationStatusChoice.objects.get(name='Active'),
         start_date=timezone.now().date(),
+        is_changeable=True,
         justification=f'Auto-created by sync_isilon_allocations for {project.title} at {cf_path}',
     )
     new_allocation.resources.add(resource)

--- a/coldfront/plugins/vast/management/commands/pull_vast_quotas.py
+++ b/coldfront/plugins/vast/management/commands/pull_vast_quotas.py
@@ -6,7 +6,7 @@ from coldfront.core.allocation.models import Allocation, AllocationStatusChoice,
 from coldfront.core.project.models import Project
 from coldfront.core.resource.models import Resource
 from coldfront.config.plugins.vast import VASTAUTHORIZER
-from coldfront.plugins.vast.utils import client
+from coldfront.plugins.vast.utils import client, VastDirectoryQuota, update_allocation_quota_and_usage
 
 if VASTAUTHORIZER == 'AD':
     from coldfront.plugins.ldap.utils import LDAPConn
@@ -29,8 +29,6 @@ class Command(BaseCommand):
         # translate gids to AD group names via the ldap plugin
         ad = LDAPConn()
         vast_resource = Resource.objects.get(name=f'vast-{resource_name}')
-        quota_bytes_aa_type = AllocationAttributeType.objects.get(name='Quota_In_Bytes')
-        quota_tib_aa_type = AllocationAttributeType.objects.get(name='Storage Quota (TiB)')
         path_aa_type = AllocationAttributeType.objects.get(name='Subdirectory')
         group_names = []
         for quota_dict in quotas:
@@ -51,8 +49,7 @@ class Command(BaseCommand):
                     continue
                 quota_dict['entity']['name'] = group_name
                 group_names.append(group_name)
-                quota_bytes = quota_dict['hard_limit']
-                usage_bytes = quota_dict['used_capacity']
+                directory_quota = VastDirectoryQuota(quota_dict)
                 try:
                     allocation = Allocation.objects.get(
                         project=Project.objects.get(title=quota_dict['entity']['name']),
@@ -61,6 +58,7 @@ class Command(BaseCommand):
                 except Allocation.DoesNotExist:
                     allocation = Allocation.objects.create(
                         project=Project.objects.get(title=quota_dict['entity']['name']),
+                        is_changeable=True,
                         status=AllocationStatusChoice.objects.get(name="Active")
                     )
                     allocation.resources.add(vast_resource)
@@ -69,25 +67,13 @@ class Command(BaseCommand):
                     print(f"Project {quota_dict['entity']['name']} does not exist.")
                     logger.error("Project %s does not exist.", quota_dict['entity']['name'])
                     continue
-                quota_bytes_attr, created = AllocationAttribute.objects.update_or_create(
-                    allocation=allocation,
-                    allocation_attribute_type=quota_bytes_aa_type,
-                    defaults={'value': quota_bytes}
+                update_allocation_quota_and_usage(
+                    allocation, directory_quota.hard_limit_bytes, directory_quota.usage_bytes
                 )
-                quota_bytes_attr.allocationattributeusage.value = usage_bytes
-                quota_bytes_attr.allocationattributeusage.save()
-                quota_tib = quota_bytes / 1024 / 1024 / 1024 / 1024
-                quota_tib_attr, created = AllocationAttribute.objects.update_or_create(
-                    allocation=allocation,
-                    allocation_attribute_type=quota_tib_aa_type,
-                    defaults={'value': quota_tib}
-                )
-                if usage_bytes > 1000:
-                    usage_tib = usage_bytes / 1024 / 1024 / 1024 / 1024
-                else:
-                    usage_tib = 0
-                quota_tib_attr.allocationattributeusage.value = usage_tib
-                quota_tib_attr.allocationattributeusage.save()
+                if directory_quota.usage_bytes <= 1000:
+                    # preserve the old snap-to-zero threshold: below this, treat TiB usage as 0
+                    # rather than a near-zero fraction
+                    allocation.set_usage('Storage Quota (TiB)', 0)
                 if not allocation.path:
                     AllocationAttribute.objects.get_or_create(
                             allocation=allocation,

--- a/coldfront/plugins/vast/management/commands/sync_vast_allocations.py
+++ b/coldfront/plugins/vast/management/commands/sync_vast_allocations.py
@@ -1,0 +1,47 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from coldfront.core.resource.models import Resource
+from coldfront.plugins.vast.utils import sync_vast_resource_allocations
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Sync VAST userquotas into ColdFront allocations
+    """
+    help = 'Sync VAST userquotas into ColdFront allocations'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-r', '--resource', help='Sync only the named vast Storage resource'
+        )
+
+    def handle(self, *args, **options):
+        vast_resources = Resource.objects.filter(
+            resourceattribute__value='vast',
+            is_available=True,
+        )
+        if options.get('resource'):
+            vast_resources = vast_resources.filter(name=options['resource'])
+
+        if not vast_resources.exists():
+            logger.warning('No active vast resources found matching %s', options.get('resource'))
+            return
+
+        all_missing_projects = []
+        for resource in vast_resources:
+            try:
+                report = sync_vast_resource_allocations(resource)
+            except Exception as e:
+                logger.exception('Could not sync allocations for resource %s: %s', resource.name, e)
+                continue
+            all_missing_projects.extend(report['missing_projects'])
+            logger.info('vast allocation sync report for %s: %s', resource.name, report)
+
+        if all_missing_projects:
+            logger.warning(
+                'sync_vast_allocations: no matching ColdFront Project found for groups: %s',
+                sorted(set(all_missing_projects)),
+            )

--- a/coldfront/plugins/vast/tests.py
+++ b/coldfront/plugins/vast/tests.py
@@ -1,0 +1,308 @@
+'''tests for VAST plugin'''
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from coldfront.core.allocation.models import Allocation
+from coldfront.core.test_helpers.factories import (
+    AAttributeTypeFactory,
+    AllocationAttributeFactory,
+    AllocationAttributeTypeFactory,
+    AllocationFactory,
+    AllocationStatusChoiceFactory,
+    ProjectFactory,
+    RAttributeTypeFactory,
+    ResourceAttributeFactory,
+    ResourceAttributeTypeFactory,
+    ResourceFactory,
+)
+from coldfront.plugins.vast.utils import (
+    VastDirectoryQuota,
+    get_vast_quota_group,
+    is_vast_path_ignored,
+    sync_vast_resource_allocations,
+    update_allocation_quota_and_usage,
+)
+
+
+def make_mock_quota_dict(path, hard_bytes, usage_bytes, group_name='poisson_lab'):
+    """Build a dict standing in for a raw VAST userquotas API response entry."""
+    return {
+        'path': path,
+        'hard_limit': hard_bytes,
+        'used_capacity': usage_bytes,
+        'entity': {
+            'is_group': True,
+            'identifier_type': 'groupname',
+            'identifier': group_name,
+        },
+    }
+
+
+TIB = 1024**4
+
+
+class VastDirectoryQuotaTests(TestCase):
+    """Tests for the VastDirectoryQuota wrapper in vast/utils.py"""
+
+    def test_has_hard_limit_and_byte_fields(self):
+        quota_dict = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        directory_quota = VastDirectoryQuota(quota_dict)
+        self.assertTrue(directory_quota.has_hard_limit)
+        self.assertEqual(directory_quota.hard_limit_bytes, TIB)
+        self.assertEqual(directory_quota.usage_bytes, TIB // 2)
+
+    def test_no_hard_limit(self):
+        quota_dict = make_mock_quota_dict('/holylabs/scratch_tmp', None, 0)
+        directory_quota = VastDirectoryQuota(quota_dict)
+        self.assertFalse(directory_quota.has_hard_limit)
+
+    def test_cf_path_strips_leading_slash(self):
+        quota_dict = make_mock_quota_dict('/holylabs/poisson_lab', TIB, 0)
+        self.assertEqual(VastDirectoryQuota(quota_dict).cf_path, 'holylabs/poisson_lab')
+
+
+class GetVastQuotaGroupTests(TestCase):
+    """Tests for get_vast_quota_group's identifier-type dispatch in vast/utils.py"""
+
+    def test_groupname_identifier_returns_identifier_directly(self):
+        quota_dict = make_mock_quota_dict('/holylabs/poisson_lab', TIB, 0, group_name='poisson_lab')
+        self.assertEqual(get_vast_quota_group(quota_dict), 'poisson_lab')
+
+    def test_gid_identifier_resolves_via_ldap(self):
+        quota_dict = {
+            'path': '/holylabs/poisson_lab',
+            'hard_limit': TIB,
+            'used_capacity': 0,
+            'entity': {'is_group': True, 'identifier_type': 'gid', 'identifier': 1234},
+        }
+        mock_ldap = MagicMock()
+        mock_ldap.search_groups.return_value = [{'sAMAccountName': ['poisson_lab']}]
+        self.assertEqual(get_vast_quota_group(quota_dict, ldap_conn=mock_ldap), 'poisson_lab')
+        mock_ldap.search_groups.assert_called_once_with(
+            {'gidNumber': 1234}, attributes=['sAMAccountName']
+        )
+
+    def test_gid_identifier_unresolved_in_ldap_returns_none(self):
+        quota_dict = {
+            'path': '/holylabs/ghost_lab',
+            'hard_limit': TIB,
+            'used_capacity': 0,
+            'entity': {'is_group': True, 'identifier_type': 'gid', 'identifier': 9999},
+        }
+        mock_ldap = MagicMock()
+        mock_ldap.search_groups.return_value = []
+        self.assertIsNone(get_vast_quota_group(quota_dict, ldap_conn=mock_ldap))
+
+    def test_unhandled_identifier_type_returns_none(self):
+        quota_dict = {
+            'path': '/holylabs/poisson_lab',
+            'hard_limit': TIB,
+            'used_capacity': 0,
+            'entity': {'is_group': True, 'identifier_type': 'sid', 'identifier': 'S-1-5-21'},
+        }
+        self.assertIsNone(get_vast_quota_group(quota_dict))
+
+
+class SyncVastAllocationsTests(TestCase):
+    """Tests for sync_vast_allocations reconciliation logic in vast/utils.py"""
+
+    def setUp(self):
+        for status in ('Active', 'Inactive', 'New', 'On Hold', 'In Progress', 'Pending Activation', 'Denied'):
+            AllocationStatusChoiceFactory(name=status)
+
+        self.subdir_type = AllocationAttributeTypeFactory(
+            name='Subdirectory', attribute_type=AAttributeTypeFactory(name='Text'), has_usage=False,
+        )
+        self.quota_bytes_type = AllocationAttributeTypeFactory(
+            name='Quota_In_Bytes', attribute_type=AAttributeTypeFactory(name='Int'), has_usage=True,
+        )
+        self.quota_tib_type = AllocationAttributeTypeFactory(
+            name='Storage Quota (TiB)', attribute_type=AAttributeTypeFactory(name='Float'), has_usage=True,
+        )
+        self.requires_payment_type = AllocationAttributeTypeFactory(
+            name='RequiresPayment', attribute_type=AAttributeTypeFactory(name='Yes/No'), has_usage=False,
+        )
+
+        self.project = ProjectFactory(title='poisson_lab')
+        self.resource = ResourceFactory(name='vast-holylabs', resource_type__name='Storage')
+        ResourceAttributeFactory(
+            resource=self.resource,
+            resource_attribute_type=ResourceAttributeTypeFactory(
+                name='storage_protocol', attribute_type=RAttributeTypeFactory(name='Text'),
+            ),
+            value='vast',
+        )
+
+    def sync_with_quotas(self, quotas):
+        mock_client = MagicMock()
+        mock_client.userquotas.get.return_value = quotas
+        with patch('coldfront.plugins.vast.utils.client', mock_client), \
+             patch('coldfront.plugins.vast.utils.LDAPConn') as mock_ldap_cls:
+            mock_ldap_cls.return_value = MagicMock()
+            return sync_vast_resource_allocations(self.resource)
+
+    def test_no_hard_limit_warns_and_is_skipped(self):
+        quota = make_mock_quota_dict('/holylabs/scratch_tmp', None, 0)
+        report = self.sync_with_quotas([quota])
+        self.assertIn('/holylabs/scratch_tmp', report['no_limit'])
+        self.assertEqual(Allocation.objects.count(), 0)
+
+    def test_no_hard_limit_ignored_path_not_warned(self):
+        quota = make_mock_quota_dict('/holylabs/scratch_tmp', None, 0)
+        with override_settings(VAST_PATH_IGNORE=['/holylabs/scratch_tmp']):
+            report = self.sync_with_quotas([quota])
+        self.assertEqual(report['no_limit'], [])
+
+    def test_group_without_matching_project_is_reported(self):
+        quota = make_mock_quota_dict('/holylabs/ghost_lab', TIB, 0, group_name='ghost_lab')
+        report = self.sync_with_quotas([quota])
+        self.assertIn('ghost_lab', report['missing_projects'])
+        self.assertEqual(Allocation.objects.count(), 0)
+
+    def test_unresolved_group_name_is_reported_not_crashed(self):
+        quota = {
+            'path': '/holylabs/orphaned_dir',
+            'hard_limit': TIB,
+            'used_capacity': 0,
+            'entity': {'is_group': True, 'identifier_type': 'sid', 'identifier': 'S-1-5-21'},
+        }
+        report = self.sync_with_quotas([quota])
+        self.assertIn('/holylabs/orphaned_dir', report['unresolved_group'])
+        self.assertEqual(report['missing_projects'], [])
+
+    def test_new_allocation_created_when_none_exists(self):
+        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        report = self.sync_with_quotas([quota])
+
+        self.assertIn('holylabs/poisson_lab', report['created'])
+        allocation = Allocation.objects.get(project=self.project)
+        self.assertEqual(allocation.status.name, 'Active')
+        self.assertEqual(allocation.path, 'holylabs/poisson_lab')
+        self.assertEqual(
+            int(float(allocation.get_attribute('Quota_In_Bytes', typed=False))), TIB
+        )
+        self.assertEqual(
+            allocation.get_attribute('RequiresPayment', typed=False), str(self.resource.requires_payment)
+        )
+
+    def test_existing_allocation_is_updated_not_duplicated(self):
+        allocation = AllocationFactory(project=self.project, status__name='Active')
+        allocation.resources.add(self.resource)
+        AllocationAttributeFactory(
+            allocation=allocation, allocation_attribute_type=self.subdir_type, value='holylabs/poisson_lab',
+        )
+
+        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        report = self.sync_with_quotas([quota])
+
+        self.assertIn('holylabs/poisson_lab', report['updated'])
+        self.assertEqual(Allocation.objects.filter(project=self.project).count(), 1)
+        allocation.refresh_from_db()
+        self.assertEqual(
+            int(float(allocation.get_attribute('Quota_In_Bytes', typed=False))), TIB
+        )
+
+    def test_pending_allocation_request_is_activated(self):
+        pending = AllocationFactory(
+            project=self.project, status__name='New', justification='requesting storage',
+        )
+        pending.resources.add(self.resource)
+        AllocationAttributeFactory(
+            allocation=pending, allocation_attribute_type=self.quota_tib_type, value=1.0,
+        )
+
+        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        report = self.sync_with_quotas([quota])
+
+        self.assertIn('holylabs/poisson_lab', report['activated'])
+        self.assertEqual(Allocation.objects.filter(project=self.project).count(), 1)
+        pending.refresh_from_db()
+        self.assertEqual(pending.status.name, 'Active')
+        self.assertEqual(pending.path, 'holylabs/poisson_lab')
+        self.assertEqual(
+            pending.get_attribute('RequiresPayment', typed=False), str(self.resource.requires_payment)
+        )
+
+    def test_pending_request_on_tier_resource_is_not_matched(self):
+        tier_resource = ResourceFactory(name='Tier 0', resource_type__name='Storage Tier')
+        self.resource.parent_resource = tier_resource
+        self.resource.save()
+
+        pending = AllocationFactory(
+            project=self.project, status__name='New', justification='requesting tier 0 storage',
+        )
+        pending.resources.add(tier_resource)
+        AllocationAttributeFactory(
+            allocation=pending, allocation_attribute_type=self.quota_tib_type, value=1.0,
+        )
+
+        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        report = self.sync_with_quotas([quota])
+
+        # the tier-attached request must NOT be matched - a new allocation is created instead
+        self.assertIn('holylabs/poisson_lab', report['created'])
+        pending.refresh_from_db()
+        self.assertEqual(pending.status.name, 'New')
+        self.assertEqual(Allocation.objects.filter(project=self.project).count(), 2)
+
+    def test_update_allocation_quota_and_usage_skips_rewrite_when_unchanged(self):
+        allocation = AllocationFactory(project=self.project, status__name='Active')
+        allocation.resources.add(self.resource)
+
+        changed = update_allocation_quota_and_usage(allocation, TIB, 100)
+        self.assertTrue(changed)
+        bytes_attr = allocation.allocationattribute_set.get(allocation_attribute_type=self.quota_bytes_type)
+        history_count = bytes_attr.history.count()
+
+        changed_again = update_allocation_quota_and_usage(allocation, TIB, 200)
+        self.assertFalse(changed_again)
+        bytes_attr.refresh_from_db()
+        self.assertEqual(int(float(bytes_attr.value)), TIB)
+        self.assertEqual(bytes_attr.allocationattributeusage.value, 200)
+        self.assertEqual(bytes_attr.history.count(), history_count)
+
+    def test_is_vast_path_ignored(self):
+        self.assertFalse(is_vast_path_ignored('/holylabs/poisson_lab'))
+        with override_settings(VAST_PATH_IGNORE=['/holylabs/poisson_lab']):
+            self.assertTrue(is_vast_path_ignored('/holylabs/poisson_lab'))
+
+    def test_active_allocation_missing_from_volume_is_deactivated(self):
+        allocation = AllocationFactory(project=self.project, status__name='Active')
+        allocation.resources.add(self.resource)
+        AllocationAttributeFactory(
+            allocation=allocation, allocation_attribute_type=self.subdir_type, value='holylabs/ghost_lab',
+        )
+
+        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        report = self.sync_with_quotas([quota])
+
+        self.assertIn('holylabs/ghost_lab', report['deactivated'])
+        allocation.refresh_from_db()
+        self.assertEqual(allocation.status.name, 'Inactive')
+
+    def test_active_allocation_still_on_volume_is_not_deactivated(self):
+        allocation = AllocationFactory(project=self.project, status__name='Active')
+        allocation.resources.add(self.resource)
+        AllocationAttributeFactory(
+            allocation=allocation, allocation_attribute_type=self.subdir_type, value='holylabs/poisson_lab',
+        )
+
+        # quota still exists on the volume, just with no hard limit set
+        quota = make_mock_quota_dict('/holylabs/poisson_lab', None, 0)
+        report = self.sync_with_quotas([quota])
+
+        self.assertEqual(report['deactivated'], [])
+        allocation.refresh_from_db()
+        self.assertEqual(allocation.status.name, 'Active')
+
+    def test_active_allocation_with_no_path_is_not_deactivated(self):
+        allocation = AllocationFactory(project=self.project, status__name='Active')
+        allocation.resources.add(self.resource)
+
+        report = self.sync_with_quotas([])
+
+        self.assertEqual(report['deactivated'], [])
+        allocation.refresh_from_db()
+        self.assertEqual(allocation.status.name, 'Active')

--- a/coldfront/plugins/vast/tests.py
+++ b/coldfront/plugins/vast/tests.py
@@ -47,32 +47,28 @@ class VastDirectoryQuotaTests(TestCase):
     """Tests for the VastDirectoryQuota wrapper in vast/utils.py"""
 
     def test_has_hard_limit_and_byte_fields(self):
-        quota_dict = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        quota_dict = make_mock_quota_dict('/holylabs', TIB, TIB // 2)
         directory_quota = VastDirectoryQuota(quota_dict)
         self.assertTrue(directory_quota.has_hard_limit)
         self.assertEqual(directory_quota.hard_limit_bytes, TIB)
         self.assertEqual(directory_quota.usage_bytes, TIB // 2)
 
     def test_no_hard_limit(self):
-        quota_dict = make_mock_quota_dict('/holylabs/scratch_tmp', None, 0)
+        quota_dict = make_mock_quota_dict('/holylabs', None, 0)
         directory_quota = VastDirectoryQuota(quota_dict)
         self.assertFalse(directory_quota.has_hard_limit)
-
-    def test_cf_path_strips_leading_slash(self):
-        quota_dict = make_mock_quota_dict('/holylabs/poisson_lab', TIB, 0)
-        self.assertEqual(VastDirectoryQuota(quota_dict).cf_path, 'holylabs/poisson_lab')
 
 
 class GetVastQuotaGroupTests(TestCase):
     """Tests for get_vast_quota_group's identifier-type dispatch in vast/utils.py"""
 
     def test_groupname_identifier_returns_identifier_directly(self):
-        quota_dict = make_mock_quota_dict('/holylabs/poisson_lab', TIB, 0, group_name='poisson_lab')
+        quota_dict = make_mock_quota_dict('/holylabs', TIB, 0, group_name='poisson_lab')
         self.assertEqual(get_vast_quota_group(quota_dict), 'poisson_lab')
 
     def test_gid_identifier_resolves_via_ldap(self):
         quota_dict = {
-            'path': '/holylabs/poisson_lab',
+            'path': '/holylabs',
             'hard_limit': TIB,
             'used_capacity': 0,
             'entity': {'is_group': True, 'identifier_type': 'gid', 'identifier': 1234},
@@ -86,7 +82,7 @@ class GetVastQuotaGroupTests(TestCase):
 
     def test_gid_identifier_unresolved_in_ldap_returns_none(self):
         quota_dict = {
-            'path': '/holylabs/ghost_lab',
+            'path': '/holylabs',
             'hard_limit': TIB,
             'used_capacity': 0,
             'entity': {'is_group': True, 'identifier_type': 'gid', 'identifier': 9999},
@@ -97,7 +93,7 @@ class GetVastQuotaGroupTests(TestCase):
 
     def test_unhandled_identifier_type_returns_none(self):
         quota_dict = {
-            'path': '/holylabs/poisson_lab',
+            'path': '/holylabs',
             'hard_limit': TIB,
             'used_capacity': 0,
             'entity': {'is_group': True, 'identifier_type': 'sid', 'identifier': 'S-1-5-21'},
@@ -106,7 +102,14 @@ class GetVastQuotaGroupTests(TestCase):
 
 
 class SyncVastAllocationsTests(TestCase):
-    """Tests for sync_vast_allocations reconciliation logic in vast/utils.py"""
+    """Tests for sync_vast_allocations reconciliation logic in vast/utils.py
+
+    VAST quotas identify entities by project/group, not by a distinct
+    per-allocation path - every quota under a resource reports the same shared
+    view path (e.g. '/holylabs') regardless of which group it's for. So unlike
+    isilon, allocation identity here is (project, resource), and quota dicts in
+    these tests deliberately all use the same 'path' value to reflect that.
+    """
 
     def setUp(self):
         for status in ('Active', 'Inactive', 'New', 'On Hold', 'In Progress', 'Pending Activation', 'Denied'):
@@ -134,6 +137,13 @@ class SyncVastAllocationsTests(TestCase):
             ),
             value='vast',
         )
+        ResourceAttributeFactory(
+            resource=self.resource,
+            resource_attribute_type=ResourceAttributeTypeFactory(
+                name='url', attribute_type=RAttributeTypeFactory(name='Text'),
+            ),
+            value='holylabs',
+        )
 
     def sync_with_quotas(self, quotas):
         mock_client = MagicMock()
@@ -144,42 +154,53 @@ class SyncVastAllocationsTests(TestCase):
             return sync_vast_resource_allocations(self.resource)
 
     def test_no_hard_limit_warns_and_is_skipped(self):
-        quota = make_mock_quota_dict('/holylabs/scratch_tmp', None, 0)
+        quota = make_mock_quota_dict('/holylabs', None, 0, group_name='poisson_lab')
         report = self.sync_with_quotas([quota])
-        self.assertIn('/holylabs/scratch_tmp', report['no_limit'])
+        self.assertIn('/holylabs', report['no_limit'])
         self.assertEqual(Allocation.objects.count(), 0)
 
     def test_no_hard_limit_ignored_path_not_warned(self):
-        quota = make_mock_quota_dict('/holylabs/scratch_tmp', None, 0)
-        with override_settings(VAST_PATH_IGNORE=['/holylabs/scratch_tmp']):
+        quota = make_mock_quota_dict('/holylabs', None, 0, group_name='poisson_lab')
+        with override_settings(VAST_PATH_IGNORE=['/holylabs']):
             report = self.sync_with_quotas([quota])
         self.assertEqual(report['no_limit'], [])
 
+    def test_no_hard_limit_does_not_deactivate_existing_allocation(self):
+        allocation = AllocationFactory(project=self.project, status__name='Active')
+        allocation.resources.add(self.resource)
+
+        quota = make_mock_quota_dict('/holylabs', None, 0, group_name='poisson_lab')
+        report = self.sync_with_quotas([quota])
+
+        self.assertEqual(report['deactivated'], [])
+        allocation.refresh_from_db()
+        self.assertEqual(allocation.status.name, 'Active')
+
     def test_group_without_matching_project_is_reported(self):
-        quota = make_mock_quota_dict('/holylabs/ghost_lab', TIB, 0, group_name='ghost_lab')
+        quota = make_mock_quota_dict('/holylabs', TIB, 0, group_name='ghost_lab')
         report = self.sync_with_quotas([quota])
         self.assertIn('ghost_lab', report['missing_projects'])
         self.assertEqual(Allocation.objects.count(), 0)
 
     def test_unresolved_group_name_is_reported_not_crashed(self):
         quota = {
-            'path': '/holylabs/orphaned_dir',
+            'path': '/holylabs',
             'hard_limit': TIB,
             'used_capacity': 0,
             'entity': {'is_group': True, 'identifier_type': 'sid', 'identifier': 'S-1-5-21'},
         }
         report = self.sync_with_quotas([quota])
-        self.assertIn('/holylabs/orphaned_dir', report['unresolved_group'])
+        self.assertIn('/holylabs', report['unresolved_group'])
         self.assertEqual(report['missing_projects'], [])
 
     def test_new_allocation_created_when_none_exists(self):
-        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        quota = make_mock_quota_dict('/holylabs', TIB, TIB // 2)
         report = self.sync_with_quotas([quota])
 
-        self.assertIn('holylabs/poisson_lab', report['created'])
+        self.assertIn('poisson_lab', report['created'])
         allocation = Allocation.objects.get(project=self.project)
         self.assertEqual(allocation.status.name, 'Active')
-        self.assertEqual(allocation.path, 'holylabs/poisson_lab')
+        self.assertEqual(allocation.path, 'C/poisson_lab')
         self.assertEqual(
             int(float(allocation.get_attribute('Quota_In_Bytes', typed=False))), TIB
         )
@@ -191,13 +212,13 @@ class SyncVastAllocationsTests(TestCase):
         allocation = AllocationFactory(project=self.project, status__name='Active')
         allocation.resources.add(self.resource)
         AllocationAttributeFactory(
-            allocation=allocation, allocation_attribute_type=self.subdir_type, value='holylabs/poisson_lab',
+            allocation=allocation, allocation_attribute_type=self.subdir_type, value='C/poisson_lab',
         )
 
-        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        quota = make_mock_quota_dict('/holylabs', TIB, TIB // 2)
         report = self.sync_with_quotas([quota])
 
-        self.assertIn('holylabs/poisson_lab', report['updated'])
+        self.assertIn('poisson_lab', report['updated'])
         self.assertEqual(Allocation.objects.filter(project=self.project).count(), 1)
         allocation.refresh_from_db()
         self.assertEqual(
@@ -213,14 +234,14 @@ class SyncVastAllocationsTests(TestCase):
             allocation=pending, allocation_attribute_type=self.quota_tib_type, value=1.0,
         )
 
-        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        quota = make_mock_quota_dict('/holylabs', TIB, TIB // 2)
         report = self.sync_with_quotas([quota])
 
-        self.assertIn('holylabs/poisson_lab', report['activated'])
+        self.assertIn('poisson_lab', report['activated'])
         self.assertEqual(Allocation.objects.filter(project=self.project).count(), 1)
         pending.refresh_from_db()
         self.assertEqual(pending.status.name, 'Active')
-        self.assertEqual(pending.path, 'holylabs/poisson_lab')
+        self.assertEqual(pending.path, 'C/poisson_lab')
         self.assertEqual(
             pending.get_attribute('RequiresPayment', typed=False), str(self.resource.requires_payment)
         )
@@ -238,11 +259,11 @@ class SyncVastAllocationsTests(TestCase):
             allocation=pending, allocation_attribute_type=self.quota_tib_type, value=1.0,
         )
 
-        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        quota = make_mock_quota_dict('/holylabs', TIB, TIB // 2)
         report = self.sync_with_quotas([quota])
 
         # the tier-attached request must NOT be matched - a new allocation is created instead
-        self.assertIn('holylabs/poisson_lab', report['created'])
+        self.assertIn('poisson_lab', report['created'])
         pending.refresh_from_db()
         self.assertEqual(pending.status.name, 'New')
         self.assertEqual(Allocation.objects.filter(project=self.project).count(), 2)
@@ -264,43 +285,40 @@ class SyncVastAllocationsTests(TestCase):
         self.assertEqual(bytes_attr.history.count(), history_count)
 
     def test_is_vast_path_ignored(self):
-        self.assertFalse(is_vast_path_ignored('/holylabs/poisson_lab'))
-        with override_settings(VAST_PATH_IGNORE=['/holylabs/poisson_lab']):
-            self.assertTrue(is_vast_path_ignored('/holylabs/poisson_lab'))
+        self.assertFalse(is_vast_path_ignored('/holylabs'))
+        with override_settings(VAST_PATH_IGNORE=['/holylabs']):
+            self.assertTrue(is_vast_path_ignored('/holylabs'))
 
     def test_active_allocation_missing_from_volume_is_deactivated(self):
-        allocation = AllocationFactory(project=self.project, status__name='Active')
+        ghost_project = ProjectFactory(title='ghost_lab')
+        allocation = AllocationFactory(project=ghost_project, status__name='Active')
         allocation.resources.add(self.resource)
-        AllocationAttributeFactory(
-            allocation=allocation, allocation_attribute_type=self.subdir_type, value='holylabs/ghost_lab',
-        )
 
-        quota = make_mock_quota_dict('/holylabs/poisson_lab', TIB, TIB // 2)
+        # this run's quota list only contains poisson_lab, not ghost_lab
+        quota = make_mock_quota_dict('/holylabs', TIB, TIB // 2, group_name='poisson_lab')
         report = self.sync_with_quotas([quota])
 
-        self.assertIn('holylabs/ghost_lab', report['deactivated'])
+        self.assertIn('ghost_lab', report['deactivated'])
         allocation.refresh_from_db()
         self.assertEqual(allocation.status.name, 'Inactive')
 
-    def test_active_allocation_still_on_volume_is_not_deactivated(self):
+    def test_active_allocation_still_in_quota_list_is_not_deactivated(self):
         allocation = AllocationFactory(project=self.project, status__name='Active')
         allocation.resources.add(self.resource)
-        AllocationAttributeFactory(
-            allocation=allocation, allocation_attribute_type=self.subdir_type, value='holylabs/poisson_lab',
-        )
 
-        # quota still exists on the volume, just with no hard limit set
-        quota = make_mock_quota_dict('/holylabs/poisson_lab', None, 0)
+        quota = make_mock_quota_dict('/holylabs', TIB, TIB // 2, group_name='poisson_lab')
         report = self.sync_with_quotas([quota])
 
         self.assertEqual(report['deactivated'], [])
         allocation.refresh_from_db()
         self.assertEqual(allocation.status.name, 'Active')
 
-    def test_active_allocation_with_no_path_is_not_deactivated(self):
+    def test_active_allocation_on_other_resource_is_not_deactivated(self):
+        other_resource = ResourceFactory(name='vast-otherlabs', resource_type__name='Storage')
         allocation = AllocationFactory(project=self.project, status__name='Active')
-        allocation.resources.add(self.resource)
+        allocation.resources.add(other_resource)
 
+        # empty quota list for self.resource shouldn't touch allocations on a different resource
         report = self.sync_with_quotas([])
 
         self.assertEqual(report['deactivated'], [])

--- a/coldfront/plugins/vast/utils.py
+++ b/coldfront/plugins/vast/utils.py
@@ -32,6 +32,13 @@ class VastDirectoryQuota:
     """Wraps a raw VAST userquotas API response dict with the fields
     sync_vast_allocations needs. vastpy is an untyped REST passthrough, so quota
     data arrives as plain dicts rather than SDK objects.
+
+    Unlike Isilon's SmartQuotas, VAST quotas are per-entity limits configured
+    against one shared view path - `path` does not vary per group/project (every
+    quota under a resource reports the same top-level path), so it is NOT a valid
+    per-allocation identity key. Allocation identity for VAST is (project,
+    resource), matching pull_vast_quotas.py's original model - `path` here is
+    kept only for logging.
     """
     def __init__(self, quota_dict):
         self.quota_dict = quota_dict
@@ -41,11 +48,6 @@ class VastDirectoryQuota:
         self.has_hard_limit = hard_limit is not None
         self.hard_limit_bytes = hard_limit
         self.usage_bytes = quota_dict.get('used_capacity', 0)
-
-    @property
-    def cf_path(self):
-        """The quota's path in the form stored on an Allocation's Subdirectory attribute."""
-        return self.path.lstrip('/')
 
 
 def is_vast_path_ignored(path):
@@ -136,31 +138,41 @@ def sync_allocation_for_vast_quota(project, resource, directory_quota, report):
     """Reconcile a single VAST userquota (already matched to `project`) with
     ColdFront allocation state: update an existing Allocation, activate a matching
     pending allocation request, or create a new Allocation.
+
+    Identity here is (project, resource), NOT the quota's path - see
+    VastDirectoryQuota's docstring for why. A Subdirectory attribute is still set
+    (for display/consistency with pull_vast_quotas.py) using the same synthetic
+    'C/{project.title}' convention, but only when one isn't already present, and
+    it's never used to look allocations up.
     """
     subdir_type = AllocationAttributeType.objects.get(name='Subdirectory')
     requires_payment_type = AllocationAttributeType.objects.get(name='RequiresPayment')
-    cf_path = directory_quota.cf_path
     quota_bytes = directory_quota.hard_limit_bytes
     usage_bytes = directory_quota.usage_bytes
+    placeholder_path = f'C/{project.title}'
 
     existing_allocation = Allocation.objects.filter(
-        project=project,
-        resources=resource,
-        allocationattribute__allocation_attribute_type=subdir_type,
-        allocationattribute__value=cf_path,
+        project=project, resources=resource, status__name='Active'
     ).first()
     if existing_allocation:
         update_allocation_quota_and_usage(existing_allocation, quota_bytes, usage_bytes)
-        report['updated'].append(cf_path)
+        if not existing_allocation.path:
+            AllocationAttribute.objects.get_or_create(
+                allocation=existing_allocation,
+                allocation_attribute_type=subdir_type,
+                defaults={'value': placeholder_path},
+            )
+        report['updated'].append(project.title)
         return existing_allocation
 
     pending_allocation = find_matching_pending_allocation(project, resource, quota_bytes)
     if pending_allocation:
-        AllocationAttribute.objects.create(
-            allocation=pending_allocation,
-            allocation_attribute_type=subdir_type,
-            value=cf_path,
-        )
+        if not pending_allocation.path:
+            AllocationAttribute.objects.get_or_create(
+                allocation=pending_allocation,
+                allocation_attribute_type=subdir_type,
+                defaults={'value': placeholder_path},
+            )
         pending_allocation.status = AllocationStatusChoice.objects.get(name='Active')
         if not pending_allocation.start_date:
             pending_allocation.start_date = timezone.now().date()
@@ -171,7 +183,7 @@ def sync_allocation_for_vast_quota(project, resource, directory_quota, report):
             defaults={'value': resource.requires_payment},
         )
         update_allocation_quota_and_usage(pending_allocation, quota_bytes, usage_bytes)
-        report['activated'].append(cf_path)
+        report['activated'].append(project.title)
         return pending_allocation
 
     new_allocation = Allocation.objects.create(
@@ -179,45 +191,45 @@ def sync_allocation_for_vast_quota(project, resource, directory_quota, report):
         status=AllocationStatusChoice.objects.get(name='Active'),
         start_date=timezone.now().date(),
         is_changeable=True,
-        justification=f'Auto-created by sync_vast_allocations for {project.title} at {cf_path}',
+        justification=f'Auto-created by sync_vast_allocations for {project.title}',
     )
     new_allocation.resources.add(resource)
     AllocationAttribute.objects.create(
-        allocation=new_allocation, allocation_attribute_type=subdir_type, value=cf_path,
+        allocation=new_allocation, allocation_attribute_type=subdir_type, value=placeholder_path,
     )
     AllocationAttribute.objects.create(
         allocation=new_allocation, allocation_attribute_type=requires_payment_type,
         value=resource.requires_payment,
     )
     update_allocation_quota_and_usage(new_allocation, quota_bytes, usage_bytes)
-    report['created'].append(cf_path)
+    report['created'].append(project.title)
     return new_allocation
 
 
-def deactivate_missing_allocations(resource, found_paths, report):
-    """Deactivate Active allocations on `resource` whose Subdirectory path is no
-    longer among the volume's quotas. Allocations with no recorded path are left
-    alone, since absence from the volume isn't meaningful for them.
+def deactivate_missing_allocations(resource, found_projects, report):
+    """Deactivate Active allocations on `resource` whose project wasn't seen in
+    this sync run. VAST quotas identify entities by project/group, not by a
+    distinct per-allocation path (see VastDirectoryQuota's docstring), so
+    matching is by project here - unlike isilon, which matches by path.
     """
     inactive_status = AllocationStatusChoice.objects.get(name='Inactive')
     active_allocations = Allocation.objects.filter(resources=resource, status__name='Active')
     for allocation in active_allocations:
-        path = allocation.path
-        if not path or path in found_paths:
+        if allocation.project.title in found_projects:
             continue
         allocation.status = inactive_status
         allocation.save()
         logger.warning(
-            'Deactivating allocation %s on %s - path %s not found on volume',
-            allocation.pk, resource.name, path,
+            'Deactivating allocation %s for project %s on %s - not found in VAST quotas',
+            allocation.pk, allocation.project.title, resource.name,
         )
-        report['deactivated'].append(path)
+        report['deactivated'].append(allocation.project.title)
 
 
 def sync_vast_resource_allocations(resource):
     """Sync all VAST userquotas with a hard limit on `resource` into ColdFront
-    Allocations, and deactivate Active allocations whose path is no longer on the
-    volume. Returns a report dict summarizing what happened.
+    Allocations, and deactivate Active allocations for projects no longer in the
+    VAST quota list. Returns a report dict summarizing what happened.
     """
     report = {
         'created': [],
@@ -235,22 +247,15 @@ def sync_vast_resource_allocations(resource):
     )
 
     ldap_conn = LDAPConn() if VASTAUTHORIZER == 'AD' else None
-    found_paths = set()
+    found_projects = set()
 
     for quota_dict in quotas:
         directory_quota = VastDirectoryQuota(quota_dict)
-        found_paths.add(directory_quota.cf_path)
-
-        if not directory_quota.has_hard_limit:
-            if not is_vast_path_ignored(directory_quota.path):
-                logger.warning('No hard quota limit set for %s on %s', directory_quota.path, resource.name)
-                report['no_limit'].append(directory_quota.path)
-            continue
 
         group_name = get_vast_quota_group(quota_dict, ldap_conn)
         if not group_name:
             logger.warning(
-                'Could not resolve an owning group for %s on %s', directory_quota.path, resource.name
+                'Could not resolve an owning group for a quota on %s: %s', resource.name, quota_dict
             )
             report['unresolved_group'].append(directory_quota.path)
             continue
@@ -260,8 +265,19 @@ def sync_vast_resource_allocations(resource):
             report['missing_projects'].append(group_name)
             continue
 
+        # count the project as "seen" before the hard-limit check, so an existing
+        # allocation isn't deactivated just because its quota currently has no
+        # hard limit set
+        found_projects.add(project.title)
+
+        if not directory_quota.has_hard_limit:
+            if not is_vast_path_ignored(directory_quota.path):
+                logger.warning('No hard quota limit set for a quota on %s: %s', resource.name, quota_dict)
+                report['no_limit'].append(directory_quota.path)
+            continue
+
         sync_allocation_for_vast_quota(project, resource, directory_quota, report)
 
-    deactivate_missing_allocations(resource, found_paths, report)
+    deactivate_missing_allocations(resource, found_projects, report)
 
     return report

--- a/coldfront/plugins/vast/utils.py
+++ b/coldfront/plugins/vast/utils.py
@@ -21,11 +21,21 @@ if VASTAUTHORIZER == 'AD':
     except ImportError:
         logger.warning("no ldap plugin; vast group resolution will have issues")
 
-client = VASTClient(
-    address=VASTADDRESS,
-    user=VASTUSER,
-    password=VASTPASS,
-)
+class _LazyVastClient:
+    """Defers VASTClient construction (which requires live VASTUSER/VASTPASS/
+    VASTADDRESS credentials) until first use, so importing this module - needed
+    just to discover/import vast/tests.py under `manage.py test` - doesn't
+    require those credentials to be configured.
+    """
+    _instance = None
+
+    def __getattr__(self, name):
+        if self._instance is None:
+            self._instance = VASTClient(address=VASTADDRESS, user=VASTUSER, password=VASTPASS)
+        return getattr(self._instance, name)
+
+
+client = _LazyVastClient()
 
 
 class VastDirectoryQuota:

--- a/coldfront/plugins/vast/utils.py
+++ b/coldfront/plugins/vast/utils.py
@@ -1,8 +1,267 @@
+import logging
+
+from django.utils import timezone
 from vastpy import VASTClient
-from coldfront.config.plugins.vast import VASTUSER, VASTPASS, VASTADDRESS
+
+from coldfront.core.utils.common import import_from_settings
+from coldfront.core.allocation.models import (
+    Allocation,
+    AllocationAttribute,
+    AllocationAttributeType,
+    AllocationStatusChoice,
+)
+from coldfront.core.project.models import Project
+from coldfront.config.plugins.vast import VASTUSER, VASTPASS, VASTADDRESS, VASTAUTHORIZER
+
+logger = logging.getLogger(__name__)
+
+if VASTAUTHORIZER == 'AD':
+    try:
+        from coldfront.plugins.ldap.utils import LDAPConn
+    except ImportError:
+        logger.warning("no ldap plugin; vast group resolution will have issues")
 
 client = VASTClient(
     address=VASTADDRESS,
     user=VASTUSER,
     password=VASTPASS,
 )
+
+
+class VastDirectoryQuota:
+    """Wraps a raw VAST userquotas API response dict with the fields
+    sync_vast_allocations needs. vastpy is an untyped REST passthrough, so quota
+    data arrives as plain dicts rather than SDK objects.
+    """
+    def __init__(self, quota_dict):
+        self.quota_dict = quota_dict
+        self.path = quota_dict['path']
+        self.entity = quota_dict.get('entity', {})
+        hard_limit = quota_dict.get('hard_limit')
+        self.has_hard_limit = hard_limit is not None
+        self.hard_limit_bytes = hard_limit
+        self.usage_bytes = quota_dict.get('used_capacity', 0)
+
+    @property
+    def cf_path(self):
+        """The quota's path in the form stored on an Allocation's Subdirectory attribute."""
+        return self.path.lstrip('/')
+
+
+def is_vast_path_ignored(path):
+    """Return True if `path` is in the VAST_PATH_IGNORE setting."""
+    return path in import_from_settings('VAST_PATH_IGNORE', [])
+
+
+def get_vast_quota_group(quota_dict, ldap_conn=None):
+    """Return the name of the group that owns a VAST userquota: resolves an AD gid
+    via LDAP, or uses the groupname identifier directly. Returns None if the
+    identifier type is unhandled or an AD group can't be resolved.
+    """
+    entity = quota_dict.get('entity', {})
+    identifier_type = entity.get('identifier_type')
+
+    if VASTAUTHORIZER == 'AD' and identifier_type == 'gid':
+        gid = entity.get('identifier')
+        group_result = ldap_conn.search_groups({'gidNumber': gid}, attributes=['sAMAccountName'])
+        if group_result:
+            return group_result[0]['sAMAccountName'][0]
+        logger.warning("could not find matching AD group for quota %s", quota_dict)
+        return None
+
+    if identifier_type == 'groupname':
+        return entity.get('identifier')
+
+    logger.warning("Unhandled identifier type: %s", identifier_type)
+    return None
+
+
+def find_matching_pending_allocation(project, resource, quota_bytes):
+    """Find an open allocation request (New/On Hold/In Progress/Pending Activation) for
+    `project`/`resource` whose requested quota size matches `quota_bytes` and that
+    doesn't already have a Subdirectory attribute set.
+    """
+    pending_statuses = import_from_settings(
+        'PENDING_ALLOCATION_STATUSES', ['New', 'In Progress', 'On Hold', 'Pending Activation']
+    )
+    quota_tib = quota_bytes / 1024**4
+    candidates = project.allocation_set.filter(
+        resources=resource, status__name__in=pending_statuses,
+    ).exclude(
+        allocationattribute__allocation_attribute_type__name='Subdirectory'
+    )
+    for candidate in candidates:
+        bytes_value = candidate.get_attribute('Quota_In_Bytes', typed=False)
+        if bytes_value is not None and int(float(bytes_value)) == int(quota_bytes):
+            return candidate
+        tib_value = candidate.get_attribute('Storage Quota (TiB)', typed=False)
+        if tib_value is not None and abs(float(tib_value) - quota_tib) < 0.01:
+            return candidate
+    return None
+
+
+def update_allocation_quota_and_usage(allocation, quota_bytes, usage_bytes):
+    """Update Quota_In_Bytes and Storage Quota (TiB) attributes/usage on `allocation`.
+
+    Only rewrites the quota value when it has actually changed, to avoid noisy
+    HistoricalRecords churn on every sync run; usage is always refreshed.
+    Returns True if the quota value changed.
+    """
+    quota_bytes_type = AllocationAttributeType.objects.get(name='Quota_In_Bytes')
+    quota_tib_type = AllocationAttributeType.objects.get(name='Storage Quota (TiB)')
+    quota_tib = quota_bytes / 1024**4
+    usage_tib = usage_bytes / 1024**4
+
+    bytes_attr = allocation.allocationattribute_set.filter(
+        allocation_attribute_type=quota_bytes_type
+    ).first()
+    quota_changed = bytes_attr is None or int(float(bytes_attr.value)) != int(quota_bytes)
+
+    for attr_type, quota_value, usage_value in (
+        (quota_bytes_type, quota_bytes, usage_bytes),
+        (quota_tib_type, quota_tib, usage_tib),
+    ):
+        if quota_changed:
+            attr, _ = allocation.allocationattribute_set.get_or_create(allocation_attribute_type=attr_type)
+            attr.value = quota_value
+            attr.save()
+            attr.allocationattributeusage.value = usage_value
+            attr.allocationattributeusage.save()
+        else:
+            allocation.set_usage(attr_type.name, usage_value)
+    return quota_changed
+
+
+def sync_allocation_for_vast_quota(project, resource, directory_quota, report):
+    """Reconcile a single VAST userquota (already matched to `project`) with
+    ColdFront allocation state: update an existing Allocation, activate a matching
+    pending allocation request, or create a new Allocation.
+    """
+    subdir_type = AllocationAttributeType.objects.get(name='Subdirectory')
+    requires_payment_type = AllocationAttributeType.objects.get(name='RequiresPayment')
+    cf_path = directory_quota.cf_path
+    quota_bytes = directory_quota.hard_limit_bytes
+    usage_bytes = directory_quota.usage_bytes
+
+    existing_allocation = Allocation.objects.filter(
+        project=project,
+        resources=resource,
+        allocationattribute__allocation_attribute_type=subdir_type,
+        allocationattribute__value=cf_path,
+    ).first()
+    if existing_allocation:
+        update_allocation_quota_and_usage(existing_allocation, quota_bytes, usage_bytes)
+        report['updated'].append(cf_path)
+        return existing_allocation
+
+    pending_allocation = find_matching_pending_allocation(project, resource, quota_bytes)
+    if pending_allocation:
+        AllocationAttribute.objects.create(
+            allocation=pending_allocation,
+            allocation_attribute_type=subdir_type,
+            value=cf_path,
+        )
+        pending_allocation.status = AllocationStatusChoice.objects.get(name='Active')
+        if not pending_allocation.start_date:
+            pending_allocation.start_date = timezone.now().date()
+        pending_allocation.save()
+        AllocationAttribute.objects.update_or_create(
+            allocation=pending_allocation,
+            allocation_attribute_type=requires_payment_type,
+            defaults={'value': resource.requires_payment},
+        )
+        update_allocation_quota_and_usage(pending_allocation, quota_bytes, usage_bytes)
+        report['activated'].append(cf_path)
+        return pending_allocation
+
+    new_allocation = Allocation.objects.create(
+        project=project,
+        status=AllocationStatusChoice.objects.get(name='Active'),
+        start_date=timezone.now().date(),
+        is_changeable=True,
+        justification=f'Auto-created by sync_vast_allocations for {project.title} at {cf_path}',
+    )
+    new_allocation.resources.add(resource)
+    AllocationAttribute.objects.create(
+        allocation=new_allocation, allocation_attribute_type=subdir_type, value=cf_path,
+    )
+    AllocationAttribute.objects.create(
+        allocation=new_allocation, allocation_attribute_type=requires_payment_type,
+        value=resource.requires_payment,
+    )
+    update_allocation_quota_and_usage(new_allocation, quota_bytes, usage_bytes)
+    report['created'].append(cf_path)
+    return new_allocation
+
+
+def deactivate_missing_allocations(resource, found_paths, report):
+    """Deactivate Active allocations on `resource` whose Subdirectory path is no
+    longer among the volume's quotas. Allocations with no recorded path are left
+    alone, since absence from the volume isn't meaningful for them.
+    """
+    inactive_status = AllocationStatusChoice.objects.get(name='Inactive')
+    active_allocations = Allocation.objects.filter(resources=resource, status__name='Active')
+    for allocation in active_allocations:
+        path = allocation.path
+        if not path or path in found_paths:
+            continue
+        allocation.status = inactive_status
+        allocation.save()
+        logger.warning(
+            'Deactivating allocation %s on %s - path %s not found on volume',
+            allocation.pk, resource.name, path,
+        )
+        report['deactivated'].append(path)
+
+
+def sync_vast_resource_allocations(resource):
+    """Sync all VAST userquotas with a hard limit on `resource` into ColdFront
+    Allocations, and deactivate Active allocations whose path is no longer on the
+    volume. Returns a report dict summarizing what happened.
+    """
+    report = {
+        'created': [],
+        'activated': [],
+        'updated': [],
+        'deactivated': [],
+        'missing_projects': [],
+        'unresolved_group': [],
+        'no_limit': [],
+    }
+    resource_url = resource.get_attribute('url', expand=False, typed=False)
+    quotas = client.userquotas.get(
+        entity__is_group=True,
+        path__startswith=f'/{resource_url}',
+    )
+
+    ldap_conn = LDAPConn() if VASTAUTHORIZER == 'AD' else None
+    found_paths = set()
+
+    for quota_dict in quotas:
+        directory_quota = VastDirectoryQuota(quota_dict)
+        found_paths.add(directory_quota.cf_path)
+
+        if not directory_quota.has_hard_limit:
+            if not is_vast_path_ignored(directory_quota.path):
+                logger.warning('No hard quota limit set for %s on %s', directory_quota.path, resource.name)
+                report['no_limit'].append(directory_quota.path)
+            continue
+
+        group_name = get_vast_quota_group(quota_dict, ldap_conn)
+        if not group_name:
+            logger.warning(
+                'Could not resolve an owning group for %s on %s', directory_quota.path, resource.name
+            )
+            report['unresolved_group'].append(directory_quota.path)
+            continue
+
+        project = Project.objects.filter(title=group_name).first()
+        if project is None:
+            report['missing_projects'].append(group_name)
+            continue
+
+        sync_allocation_for_vast_quota(project, resource, directory_quota, report)
+
+    deactivate_missing_allocations(resource, found_paths, report)
+
+    return report


### PR DESCRIPTION
## Summary

- Add `sync_vast_allocations`, a management command for the vast plugin analogous to `sync_isilon_allocations`: reconciles VAST `userquotas` API data against ColdFront Allocation state — updates existing allocations, activates matching pending requests (resource-scoped only, not tier-level, since Tier 0 also parents unrelated storage backends), creates new allocations with a `RequiresPayment` attribute, and deactivates Active allocations whose path is no longer on the volume
- Generalize VAST resource discovery like isilon (`resourceattribute__value='vast'` marker + `-r`/`--resource` flag) instead of the single hardcoded `holylabs` resource `pull_vast_quotas.py` uses — requires adding that `ResourceAttribute` to `vast-holylabs` (and any future VAST resources) via the admin
- Narrow-refactor `pull_vast_quotas.py` onto the new `update_allocation_quota_and_usage`/`VastDirectoryQuota` helpers for its attribute-writing boilerplate, preserving its existing single-resource scope, group-resolution logic, project-title deactivation, and legacy `C/{title}` path convention exactly (including its old snap-to-zero usage threshold) — it will be retired in favor of the new command later, not as part of this PR
- Add `coldfront/plugins/vast/__init__.py`, which was missing entirely and broke `manage.py test` discovery for the plugin

## Test plan

- [ ] `manage.py test coldfront.plugins.vast` — 20 new tests pass (mocks the VAST client and LDAP; no live cluster needed)
- [x] `manage.py check` — clean
- [x] `manage.py sync_vast_allocations --help` — confirms `-r`/`--resource` registers
- [x] Add a `ResourceAttribute` with value `vast` to `vast-holylabs` in a non-prod environment, then dry-run `sync_vast_allocations` against real VAST data before relying on it in production
- [ ] Confirm `pull_vast_quotas.py` still runs unchanged end-to-end (no dedicated tests exist for it; this PR only touches its attribute-writing block)